### PR TITLE
refactor: redesign layout with new tailwind theme

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,12 +2,7 @@ import React from 'react';
 import AnnotationCanvas from './components/AnnotationCanvas';
 
 function App() {
-  return (
-    <div className="min-h-screen bg-gray-100 flex flex-col items-center">
-      <h1 className="text-3xl font-bold underline my-4">Hello Tailwind CSS</h1>
-      <AnnotationCanvas />
-    </div>
-  );
+  return <AnnotationCanvas />;
 }
 
 export default App;

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -6,3 +6,9 @@ test('renders header title', () => {
   const heading = screen.getByText(/FACADE 1/i);
   expect(heading).toBeInTheDocument();
 });
+
+test('renders image upload control', () => {
+  render(<App />);
+  const imageButton = screen.getByLabelText(/Image/i);
+  expect(imageButton).toBeInTheDocument();
+});

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders tailwind header', () => {
+test('renders header title', () => {
   render(<App />);
-  const heading = screen.getByText(/hello tailwind css/i);
+  const heading = screen.getByText(/FACADE 1/i);
   expect(heading).toBeInTheDocument();
 });

--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Canvas, Circle, Line, Rect, Polygon, Image as FabricImage } from 'fabric';
 import TopBar from './TopBar';
 import Toolbox from './Toolbox';
-import Sidebar from './Sidebar';
 import CropModal from './CropModal';
 
 const AnnotationCanvas = () => {
@@ -561,36 +560,26 @@ const AnnotationCanvas = () => {
 
 
   return (
-    <div className="relative w-full h-screen bg-gray-900 flex flex-col">
-      <TopBar
-        undo={undo}
-        redo={redo}
-        clearBoxes={clearBoxes}
-        handleImageUpload={handleImageUpload}
-      />
+    <div className="relative flex h-screen bg-gray-50">
+      <Toolbox undo={undo} redo={redo} />
 
-      <div className="flex flex-1 overflow-hidden">
-        <Toolbox
+      <main className="flex-1 flex flex-col">
+        <TopBar
           drawingActive={drawingActive}
           polygonActive={polygonActive}
           toggleDrawing={toggleDrawing}
           togglePolygonDrawing={togglePolygonDrawing}
-        />
-
-        <div className="flex-1 flex justify-center items-center bg-gray-900 p-5">
-          <canvas ref={canvasRef} className="border border-gray-700" />
-        </div>
-
-        <Sidebar
           selectedEntity={selectedEntity}
           setSelectedEntity={setSelectedEntity}
-          drawingActive={drawingActive}
-          polygonActive={polygonActive}
-          toggleDrawing={toggleDrawing}
-          togglePolygonDrawing={togglePolygonDrawing}
           exportAnnotations={exportAnnotations}
         />
-      </div>
+
+        <div className="flex-1 p-6">
+          <div className="bg-gray-100 border rounded-lg w-full h-full flex items-center justify-center">
+            <canvas ref={canvasRef} className="w-full h-full" />
+          </div>
+        </div>
+      </main>
 
       <CropModal
         cropMode={cropMode}

--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -572,6 +572,7 @@ const AnnotationCanvas = () => {
           selectedEntity={selectedEntity}
           setSelectedEntity={setSelectedEntity}
           exportAnnotations={exportAnnotations}
+          handleImageUpload={handleImageUpload}
         />
 
         <div className="flex-1 p-6">

--- a/src/components/Toolbox.js
+++ b/src/components/Toolbox.js
@@ -1,20 +1,20 @@
 import React from 'react';
 
-const Toolbox = ({ drawingActive, polygonActive, toggleDrawing, togglePolygonDrawing }) => (
-  <div className="w-16 bg-gray-800 flex flex-col items-center py-2 gap-2">
-    <div
-      className={`p-2 rounded text-white cursor-pointer ${drawingActive ? 'bg-blue-500' : 'bg-transparent'}`}
-      onClick={toggleDrawing}
+const Toolbox = ({ undo, redo }) => (
+  <aside className="w-16 bg-white border-r flex flex-col items-center space-y-4 py-4">
+    <button
+      onClick={undo}
+      className="text-gray-400 hover:text-blue-500 transition duration-200"
     >
-      ➤
-    </div>
-    <div
-      className={`p-2 rounded text-white cursor-pointer ${polygonActive ? 'bg-blue-500' : 'bg-transparent'}`}
-      onClick={togglePolygonDrawing}
+      ↶
+    </button>
+    <button
+      onClick={redo}
+      className="text-gray-400 hover:text-blue-500 transition duration-200"
     >
-      ⬟
-    </div>
-  </div>
+      ↷
+    </button>
+  </aside>
 );
 
 export default Toolbox;

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -1,44 +1,58 @@
 import React from 'react';
 
-const TopBar = ({ undo, redo, clearBoxes, handleImageUpload }) => (
-  <div className="flex justify-between items-center px-5 py-2 bg-gray-800 border-b border-gray-700">
-    <div className="flex items-center gap-2">
-      <div className="bg-gray-700 px-3 py-2 rounded text-white text-xs cursor-pointer">
-        ☰ Menu
-      </div>
-      <div
-        className="bg-gray-700 px-3 py-2 rounded text-white text-xs cursor-pointer"
-        onClick={undo}
-      >
-        ↶ Précédent
-      </div>
-      <div
-        className="bg-gray-700 px-3 py-2 rounded text-white text-xs cursor-pointer"
-        onClick={redo}
-      >
-        ↷ Suivant
-      </div>
+const TopBar = ({
+  drawingActive,
+  polygonActive,
+  toggleDrawing,
+  togglePolygonDrawing,
+  selectedEntity,
+  setSelectedEntity,
+  exportAnnotations,
+}) => (
+  <div className="flex items-center justify-between px-6 py-4 border-b bg-white">
+    <div className="text-lg font-semibold text-gray-900">
+      FACADE 1 <span className="text-gray-400 text-sm">(MANUAL)</span>
     </div>
-    <div className="flex gap-2">
+
+    <div className="flex items-center space-x-2">
       <button
-        className="bg-gray-700 text-white px-3 py-2 rounded"
-        onClick={clearBoxes}
+        onClick={toggleDrawing}
+        className={`px-4 py-1 rounded-full transition duration-200 ease-in-out shadow-sm ${
+          drawingActive
+            ? 'bg-blue-500 hover:bg-blue-600 text-white'
+            : 'bg-gray-200 text-gray-700 hover:bg-gray-100'
+        }`}
       >
-        🗑 Clear
+        Rectangle
       </button>
-      <input
-        type="file"
-        accept="image/*"
-        onChange={handleImageUpload}
-        className="hidden"
-        id="file-input"
-      />
-      <label
-        htmlFor="file-input"
-        className="bg-gray-700 px-3 py-2 rounded cursor-pointer text-white"
+      <button
+        onClick={togglePolygonDrawing}
+        className={`px-4 py-1 rounded-full transition duration-200 ease-in-out shadow-sm ${
+          polygonActive
+            ? 'bg-blue-500 hover:bg-blue-600 text-white'
+            : 'bg-gray-200 text-gray-700 hover:bg-gray-100'
+        }`}
       >
-        📁 Image
-      </label>
+        Polygon
+      </button>
+
+      <label className="text-sm text-gray-500">Type d'annotation:</label>
+      <select
+        value={selectedEntity}
+        onChange={(e) => setSelectedEntity(e.target.value)}
+        className="border rounded px-2 py-1 text-sm"
+      >
+        <option value="fenetre">Fenêtre</option>
+        <option value="porte">Porte</option>
+        <option value="facade">Façade</option>
+      </select>
+
+      <button
+        onClick={exportAnnotations}
+        className="bg-blue-500 text-white px-4 py-2 rounded-full shadow hover:bg-blue-600 transition duration-200 ease-in-out"
+      >
+        Sauvegarder
+      </button>
     </div>
   </div>
 );

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -8,6 +8,7 @@ const TopBar = ({
   selectedEntity,
   setSelectedEntity,
   exportAnnotations,
+  handleImageUpload,
 }) => (
   <div className="flex items-center justify-between px-6 py-4 border-b bg-white">
     <div className="text-lg font-semibold text-gray-900">
@@ -35,6 +36,20 @@ const TopBar = ({
       >
         Polygon
       </button>
+
+      <input
+        type="file"
+        accept="image/*"
+        onChange={handleImageUpload}
+        id="image-upload"
+        className="hidden"
+      />
+      <label
+        htmlFor="image-upload"
+        className="px-4 py-1 rounded-full bg-gray-200 text-gray-700 shadow cursor-pointer hover:bg-gray-100 transition duration-200 ease-in-out"
+      >
+        Image
+      </label>
 
       <label className="text-sm text-gray-500">Type d'annotation:</label>
       <select


### PR DESCRIPTION
## Summary
- redesign app layout with sidebar, header, and annotation canvas using light Tailwind theme
- add configurable annotation controls and save button in top bar
- move undo/redo to compact sidebar icons and update tests

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68909630bb0c8331b55459e845ba78e2