### PR TITLE
feat: improve mobile responsiveness

### DIFF
--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -560,10 +560,8 @@ const AnnotationCanvas = () => {
 
 
   return (
-    <div className="relative flex h-screen bg-gray-50">
-      <Toolbox undo={undo} redo={redo} />
-
-      <main className="flex-1 flex flex-col">
+    <div className="relative flex flex-col md:flex-row h-screen bg-gray-50">
+      <main className="flex-1 flex flex-col order-1 md:order-2">
         <TopBar
           drawingActive={drawingActive}
           polygonActive={polygonActive}
@@ -575,12 +573,14 @@ const AnnotationCanvas = () => {
           handleImageUpload={handleImageUpload}
         />
 
-        <div className="flex-1 p-6">
+        <div className="flex-1 p-2 md:p-6">
           <div className="bg-gray-100 border rounded-lg w-full h-full flex items-center justify-center">
             <canvas ref={canvasRef} className="w-full h-full" />
           </div>
         </div>
       </main>
+
+      <Toolbox undo={undo} redo={redo} />
 
       <CropModal
         cropMode={cropMode}

--- a/src/components/CropModal.js
+++ b/src/components/CropModal.js
@@ -18,7 +18,7 @@ const CropModal = ({
 
   return (
     <div className="absolute inset-0 bg-black bg-opacity-80 flex justify-center items-center z-50">
-      <div className="bg-gray-800 p-5 rounded-lg max-w-[80%] max-h-[80%] overflow-auto">
+      <div className="bg-gray-800 p-5 rounded-lg max-w-full sm:max-w-[80%] max-h-[80%] overflow-auto">
         <h3 className="text-white mb-4">Recadrer l'image</h3>
 
         <ReactCrop
@@ -30,7 +30,7 @@ const CropModal = ({
           <img
             ref={imgRef}
             src={selectedImage}
-            className="max-w-full max-h-[400px]"
+            className="max-w-full max-h-[60vh]"
             onLoad={() => {
               if (imgRef.current) {
                 const { width, height } = imgRef.current;
@@ -46,7 +46,7 @@ const CropModal = ({
           />
         </ReactCrop>
 
-        <div className="flex mt-4 gap-3">
+        <div className="flex flex-col sm:flex-row mt-4 gap-3">
           <button
             onClick={handleCropValidate}
             className="px-4 py-2 bg-green-600 text-white rounded"

--- a/src/components/Toolbox.js
+++ b/src/components/Toolbox.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const Toolbox = ({ undo, redo }) => (
-  <aside className="w-16 bg-white border-r flex flex-col items-center space-y-4 py-4">
+  <aside className="order-2 md:order-1 w-full h-16 md:w-16 md:h-auto bg-white border-t md:border-t-0 md:border-r flex flex-row md:flex-col items-center justify-center space-x-4 md:space-x-0 md:space-y-4 py-2 md:py-4">
     <button
       onClick={undo}
       className="text-gray-400 hover:text-blue-500 transition duration-200"

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -10,12 +10,12 @@ const TopBar = ({
   exportAnnotations,
   handleImageUpload,
 }) => (
-  <div className="flex items-center justify-between px-6 py-4 border-b bg-white">
+  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between px-4 sm:px-6 py-4 border-b bg-white gap-2">
     <div className="text-lg font-semibold text-gray-900">
       FACADE 1 <span className="text-gray-400 text-sm">(MANUAL)</span>
     </div>
 
-    <div className="flex items-center space-x-2">
+    <div className="flex flex-wrap items-center gap-2">
       <button
         onClick={toggleDrawing}
         className={`px-4 py-1 rounded-full transition duration-200 ease-in-out shadow-sm ${


### PR DESCRIPTION
## Summary
- reorganize layout to stack canvas and toolbox on small screens
- wrap and stack top bar controls for narrow viewports
- adjust crop modal for better small-screen display

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68909ad013b48331890a68818b60a7f2