### PR TITLE
feat: integrate lucide-react icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "fabric": "^6.7.1",
+        "lucide-react": "^0.536.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-image-crop": "^11.0.10",
@@ -11734,6 +11735,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.536.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.536.0.tgz",
+      "integrity": "sha512-2PgvNa9v+qz4Jt/ni8vPLt4jwoFybXHuubQT8fv4iCW5TjDxkbZjNZZHa485ad73NSEn/jdsEtU57eE1g+ma8A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "fabric": "^6.7.1",
+    "lucide-react": "^0.536.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-image-crop": "^11.0.10",

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Image as ImageIcon, RectangleHorizontal, Save, Shapes } from 'lucide-react';
 
 const TopBar = ({
   drawingActive,
@@ -24,7 +25,7 @@ const TopBar = ({
             : 'bg-gray-200 text-gray-700 hover:bg-gray-100'
         }`}
       >
-        Rectangle
+        <RectangleHorizontal className="inline-block mr-1" size={16} /> Rectangle
       </button>
       <button
         onClick={togglePolygonDrawing}
@@ -34,7 +35,7 @@ const TopBar = ({
             : 'bg-gray-200 text-gray-700 hover:bg-gray-100'
         }`}
       >
-        Polygon
+        <Shapes className="inline-block mr-1" size={16} /> Polygon
       </button>
 
       <input
@@ -48,7 +49,7 @@ const TopBar = ({
         htmlFor="image-upload"
         className="px-4 py-1 rounded-full bg-gray-200 text-gray-700 shadow cursor-pointer hover:bg-gray-100 transition duration-200 ease-in-out"
       >
-        Image
+        <ImageIcon className="inline-block mr-1" size={16} /> Image
       </label>
 
       <label className="text-sm text-gray-500">Type d'annotation:</label>
@@ -66,7 +67,7 @@ const TopBar = ({
         onClick={exportAnnotations}
         className="bg-blue-500 text-white px-4 py-2 rounded-full shadow hover:bg-blue-600 transition duration-200 ease-in-out"
       >
-        Sauvegarder
+        <Save className="inline-block mr-1" size={16} /> Sauvegarder
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add lucide-react dependency
- show lucide icons for rectangle, polygon, image upload and save in the top bar

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6890b4da3c648331a0e35f45dc4696ab