### PR TITLE
Replace canvas image when uploading new file

### DIFF
--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -487,8 +487,13 @@ const AnnotationCanvas = () => {
   // Fonction pour ajouter l'image directement sans crop
   const addImageDirectly = () => {
     if (!selectedImage) return;
-    
+
     const canvas = fabricRef.current;
+
+    // Supprimer l'ancienne image et les annotations existantes
+    clearBoxes();
+    canvas.getObjects('image').forEach((img) => canvas.remove(img));
+
     const htmlImg = new window.Image();
     htmlImg.src = selectedImage;
 
@@ -520,15 +525,21 @@ const AnnotationCanvas = () => {
       // Envoyer l'image au fond
       // canvas.sendToBack(fabricImg);
       canvas.requestRenderAll();
-      
+
       setCropMode(null);
       setSelectedImage(null);
     };
   };
+
 const addImageDirectlyTwo = (imageUrl) => {
   if (!imageUrl) return;
 
   const canvas = fabricRef.current;
+
+  // Supprimer l'ancienne image et les annotations existantes
+  clearBoxes();
+  canvas.getObjects('image').forEach((img) => canvas.remove(img));
+
   const htmlImg = new window.Image();
 
   htmlImg.onload = function () {


### PR DESCRIPTION
## Summary
- reset annotations and previous image before adding a newly uploaded image

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68923775faec833197fe6f1706a809df