### PR TITLE
Prevent stacked images on canvas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "fabric": "^6.7.1",
+        "lucide-react": "^0.536.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-image-crop": "^11.0.10",
@@ -11734,6 +11735,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.536.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.536.0.tgz",
+      "integrity": "sha512-2PgvNa9v+qz4Jt/ni8vPLt4jwoFybXHuubQT8fv4iCW5TjDxkbZjNZZHa485ad73NSEn/jdsEtU57eE1g+ma8A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "fabric": "^6.7.1",
+    "lucide-react": "^0.536.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-image-crop": "^11.0.10",

--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -585,12 +585,14 @@ const toggleScaleMode = () => {
       const imageUrl = event.target.result;
       setSelectedImage(imageUrl);
       setCropMode('cropImage');
-      
+
       // Réinitialiser le crop
       setCrop({ unit: '%', x: 25, y: 25, width: 50, height: 50 });
       setCompletedCrop(null);
     };
     reader.readAsDataURL(file);
+    // Reset the input so selecting the same file again re-triggers the change event
+    e.target.value = null;
   };
 
   // Ajoute une image au canvas et optionnellement révoque l'URL après ajout
@@ -598,6 +600,10 @@ const toggleScaleMode = () => {
     if (!imageUrl) return;
 
     const canvas = fabricRef.current;
+    // Remove any previously added images so the new one replaces it
+    canvas.getObjects('image').forEach((img) => canvas.remove(img));
+    canvas.requestRenderAll();
+
     const htmlImg = new window.Image();
 
     htmlImg.onload = function () {


### PR DESCRIPTION
## Summary
- remove any existing images before adding new ones to canvas
- reset image input after upload so selecting the same file can be cropped again
- add missing `lucide-react` dependency

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68933188efa4833191c938415e79de33