### PR TITLE
Refactor layout for distinct layer panel

### DIFF
--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -2,6 +2,7 @@
 import { Canvas, Circle, Line, Rect, Polygon, Image as FabricImage } from 'fabric';
 import TopBar from './TopBar';
 import Toolbox from './Toolbox';
+import LayerPanel from './LayerPanel';
 import CropModal from './CropModal';
 import CanvasWithGrid from './CanvasWithGrid';
 import ScaleModal from './ScaleModal';
@@ -727,9 +728,9 @@ const toggleScaleMode = () => {
         </div>
       </main>
 
-      <Toolbox
-        undo={undo}
-        redo={redo}
+      <Toolbox undo={undo} redo={redo} />
+
+      <LayerPanel
         layerVisibility={layerVisibility}
         toggleLayer={toggleLayer}
       />

--- a/src/components/LayerPanel.js
+++ b/src/components/LayerPanel.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+const LayerPanel = ({ layerVisibility, toggleLayer }) => (
+  <aside className="order-3 md:order-3 w-full md:w-64 bg-gradient-to-b from-white via-gray-50 to-white border-t md:border-t-0 md:border-l border-gray-200 shadow-sm p-4">
+    <div className="flex flex-col space-y-3 text-sm text-gray-700">
+      <span className="font-semibold text-gray-800">Calques</span>
+      {[
+        { key: 'fenetre', label: 'Fenêtre' },
+        { key: 'porte', label: 'Porte' },
+        { key: 'facade', label: 'Façade' },
+        { key: 'baseImage', label: 'Image de base' },
+        { key: 'processedImage', label: 'Image traitée' },
+      ].map(({ key, label }) => (
+        <label
+          key={key}
+          className="flex items-center space-x-2 px-2 py-1 rounded hover:bg-gray-100"
+        >
+          <input
+            type="checkbox"
+            className="form-checkbox h-4 w-4 text-blue-600 rounded focus:ring-blue-500"
+            checked={layerVisibility[key]}
+            onChange={() => toggleLayer(key)}
+          />
+          <span>{label}</span>
+        </label>
+      ))}
+    </div>
+  </aside>
+);
+
+export default LayerPanel;

--- a/src/components/Toolbox.js
+++ b/src/components/Toolbox.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Undo2, Redo2 } from 'lucide-react';
 
-const Toolbox = ({ undo, redo, layerVisibility, toggleLayer }) => (
-  <aside className="order-2 md:order-1 w-full md:w-64 bg-gradient-to-b from-white via-gray-50 to-white border-t md:border-t-0 md:border-r border-gray-200 shadow-sm flex flex-row md:flex-col items-center md:items-start justify-center md:justify-start space-x-6 md:space-x-0 md:space-y-6 p-4">
+const Toolbox = ({ undo, redo }) => (
+  <aside className="order-2 md:order-1 w-full md:w-64 bg-gradient-to-b from-white via-gray-50 to-white border-t md:border-t-0 md:border-r border-gray-200 shadow-sm flex flex-row md:flex-col items-center justify-center md:justify-start p-4">
     <div className="flex flex-row md:flex-col items-center space-x-4 md:space-x-0 md:space-y-4">
       <button
         onClick={undo}
@@ -18,29 +18,6 @@ const Toolbox = ({ undo, redo, layerVisibility, toggleLayer }) => (
       >
         <Redo2 className="w-5 h-5" />
       </button>
-    </div>
-    <div className="flex flex-col space-y-3 text-sm text-gray-700 w-full">
-      <span className="font-semibold text-gray-800">Calques</span>
-      {[
-        { key: 'fenetre', label: 'Fenêtre' },
-        { key: 'porte', label: 'Porte' },
-        { key: 'facade', label: 'Façade' },
-        { key: 'baseImage', label: 'Image de base' },
-        { key: 'processedImage', label: 'Image traitée' },
-      ].map(({ key, label }) => (
-        <label
-          key={key}
-          className="flex items-center space-x-2 px-2 py-1 rounded hover:bg-gray-100"
-        >
-          <input
-            type="checkbox"
-            className="form-checkbox h-4 w-4 text-blue-600 rounded focus:ring-blue-500"
-            checked={layerVisibility[key]}
-            onChange={() => toggleLayer(key)}
-          />
-          <span>{label}</span>
-        </label>
-      ))}
     </div>
   </aside>
 );

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Image as ImageIcon, Save, Ruler } from 'lucide-react';
+
 const TopBar = ({
   drawingActive,
   polygonActive,
@@ -7,7 +8,6 @@ const TopBar = ({
   toggleDrawing,
   togglePolygonDrawing,
   toggleScaleMode,
-
   selectedEntity,
   setSelectedEntity,
   exportAnnotations,
@@ -15,94 +15,97 @@ const TopBar = ({
 }) => (
   <div className="relative bg-gradient-to-r from-white via-gray-50 to-white border-b border-gray-200 shadow-sm">
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between px-6 py-5 gap-4">
-      {/* Title Section */}
-      <div className="flex items-center space-x-3">
-        <div className="w-3 h-3 bg-blue-500 rounded-full shadow-sm"></div>
-        <div>
-          <h1 className="text-xl font-bold text-gray-900 tracking-tight">
-            FACADE 1
-          </h1>
-          <span className="text-xs font-medium text-gray-400 uppercase tracking-wider">
-            Manuel
-          </span>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:gap-6 gap-4">
+        {/* Title Section */}
+        <div className="flex items-center space-x-3">
+          <div className="w-3 h-3 bg-blue-500 rounded-full shadow-sm"></div>
+          <div>
+            <h1 className="text-xl font-bold text-gray-900 tracking-tight">
+              FACADE 1
+            </h1>
+            <span className="text-xs font-medium text-gray-400 uppercase tracking-wider">
+              Manuel
+            </span>
+          </div>
+        </div>
+        {/* Controls Section */}
+        <div className="flex flex-wrap items-center gap-3">
+          {/* Drawing Tools */}
+          <div className="flex items-center bg-gray-100 rounded-full p-1 shadow-inner">
+            <button
+              onClick={toggleDrawing}
+              className={`px-5 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
+                drawingActive
+                  ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
+                  : 'text-gray-700 hover:bg-white hover:shadow-sm'
+              }`}
+            >
+              Rectangle
+            </button>
+            <button
+              onClick={togglePolygonDrawing}
+              className={`px-5 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
+                polygonActive
+                  ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
+                  : 'text-gray-700 hover:bg-white hover:shadow-sm'
+              }`}
+            >
+              Polygon
+            </button>
+            <button
+              onClick={toggleScaleMode}
+              className={`px-5 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
+                scaleActive
+                  ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
+                  : 'text-gray-700 hover:bg-white hover:shadow-sm'
+              }`}
+            >
+              <Ruler className="inline-block w-4 h-4 mr-1" />
+              Échelle
+            </button>
+          </div>
+          {/* Image Upload */}
+          <input
+            type="file"
+            accept="image/*"
+            onChange={handleImageUpload}
+            id="image-upload"
+            className="hidden"
+          />
+          <label
+            htmlFor="image-upload"
+            className="px-5 py-2 rounded-full bg-white text-gray-700 font-medium text-sm shadow-md border border-gray-200 cursor-pointer hover:bg-gray-50 hover:shadow-lg transition-all duration-200 ease-out transform hover:scale-105"
+          >
+            <ImageIcon className="inline-block w-4 h-4 mr-2" />
+            Image
+          </label>
+          {/* Annotation Type Selector */}
+          <div className="flex items-center space-x-2 bg-white rounded-full px-4 py-2 shadow-md border border-gray-200">
+            <label className="text-sm font-medium text-gray-600">Type:</label>
+            <select
+              value={selectedEntity}
+              onChange={(e) => setSelectedEntity(e.target.value)}
+              className="border-0 bg-transparent text-sm font-medium text-gray-800 focus:outline-none cursor-pointer"
+            >
+              <option value="fenetre">Fenêtre</option>
+              <option value="porte">Porte</option>
+              <option value="facade">Façade</option>
+            </select>
+          </div>
         </div>
       </div>
-      {/* Controls Section */}
-      <div className="flex flex-wrap items-center gap-3">
-        {/* Drawing Tools */}
-        <div className="flex items-center bg-gray-100 rounded-full p-1 shadow-inner">
-          <button
-            onClick={toggleDrawing}
-            className={`px-5 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
-              drawingActive
-                ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
-                : 'text-gray-700 hover:bg-white hover:shadow-sm'
-            }`}
-          >
-            Rectangle
-          </button>
-          <button
-            onClick={togglePolygonDrawing}
-            className={`px-5 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
-              polygonActive
-                ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
-                : 'text-gray-700 hover:bg-white hover:shadow-sm'
-            }`}
-          >
-            Polygon
-          </button>
-           <button
-            onClick={toggleScaleMode}
-            className={`px-5 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
-              scaleActive
-                ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
-                : 'text-gray-700 hover:bg-white hover:shadow-sm'
-            }`}
-          >
-            <Ruler className="inline-block w-4 h-4 mr-1" />
-            Échelle
-          </button>
-        </div>
-        {/* Image Upload */}
-        <input
-          type="file"
-          accept="image/*"
-          onChange={handleImageUpload}
-          id="image-upload"
-          className="hidden"
-        />
-        <label
-          htmlFor="image-upload"
-          className="px-5 py-2 rounded-full bg-white text-gray-700 font-medium text-sm shadow-md border border-gray-200 cursor-pointer hover:bg-gray-50 hover:shadow-lg transition-all duration-200 ease-out transform hover:scale-105"
-        >
-          <ImageIcon className="inline-block w-4 h-4 mr-2" />
-          Image
-        </label>
-        {/* Annotation Type Selector */}
-        <div className="flex items-center space-x-2 bg-white rounded-full px-4 py-2 shadow-md border border-gray-200">
-          <label className="text-sm font-medium text-gray-600">Type:</label>
-          <select
-            value={selectedEntity}
-            onChange={(e) => setSelectedEntity(e.target.value)}
-            className="border-0 bg-transparent text-sm font-medium text-gray-800 focus:outline-none cursor-pointer"
-          >
-            <option value="fenetre">Fenêtre</option>
-            <option value="porte">Porte</option>
-            <option value="facade">Façade</option>
-          </select>
-        </div>
-        {/* Save Button */}
-        <button
-          onClick={exportAnnotations}
-          className="bg-gradient-to-r from-blue-500 to-blue-600 text-white px-6 py-2 rounded-full font-semibold text-sm shadow-lg hover:from-blue-600 hover:to-blue-700 hover:shadow-xl transition-all duration-200 ease-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-        >
-          <Save className="inline-block w-4 h-4 mr-2" />
-           Sauvegarder
-        </button>
-      </div>
+      {/* Save Button */}
+      <button
+        onClick={exportAnnotations}
+        className="bg-gradient-to-r from-blue-500 to-blue-600 text-white px-6 py-2 rounded-full font-semibold text-sm shadow-lg hover:from-blue-600 hover:to-blue-700 hover:shadow-xl transition-all duration-200 ease-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+      >
+        <Save className="inline-block w-4 h-4 mr-2" />
+        Sauvegarder
+      </button>
     </div>
     {/* Decorative Bottom Border */}
     <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-blue-200 to-transparent"></div>
   </div>
 );
+
 export default TopBar;


### PR DESCRIPTION
## Summary
- Move layer visibility checkboxes to a dedicated right-side panel
- Keep undo/redo in the toolbox and align other top bar controls to the left
- Separate save button from other controls to remain on the right

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6896041ea8148331b707f860973491c1