### PR TITLE
Reorganize top bar and toolbox controls

### DIFF
--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -709,16 +709,8 @@ const toggleScaleMode = () => {
     <div className="relative flex flex-col md:flex-row h-screen bg-gray-50">
       <main className="flex-1 flex flex-col order-1 md:order-2">
         <TopBar
-          drawingActive={drawingActive}
-          polygonActive={polygonActive}
-          scaleActive={scaleActive}
-
-          toggleDrawing={toggleDrawing}
-          togglePolygonDrawing={togglePolygonDrawing}
-          toggleScaleMode={toggleScaleMode}
-
-          selectedEntity={selectedEntity}
-          setSelectedEntity={setSelectedEntity}
+          undo={undo}
+          redo={redo}
           exportAnnotations={exportAnnotations}
           handleImageUpload={handleImageUpload}
         />
@@ -728,7 +720,16 @@ const toggleScaleMode = () => {
         </div>
       </main>
 
-      <Toolbox undo={undo} redo={redo} />
+      <Toolbox
+        drawingActive={drawingActive}
+        polygonActive={polygonActive}
+        scaleActive={scaleActive}
+        toggleDrawing={toggleDrawing}
+        togglePolygonDrawing={togglePolygonDrawing}
+        toggleScaleMode={toggleScaleMode}
+        selectedEntity={selectedEntity}
+        setSelectedEntity={setSelectedEntity}
+      />
 
       <LayerPanel
         layerVisibility={layerVisibility}

--- a/src/components/Toolbox.js
+++ b/src/components/Toolbox.js
@@ -1,23 +1,66 @@
 import React from 'react';
-import { Undo2, Redo2 } from 'lucide-react';
+import { Ruler } from 'lucide-react';
 
-const Toolbox = ({ undo, redo }) => (
+const Toolbox = ({
+  drawingActive,
+  polygonActive,
+  scaleActive,
+  toggleDrawing,
+  togglePolygonDrawing,
+  toggleScaleMode,
+  selectedEntity,
+  setSelectedEntity,
+}) => (
   <aside className="order-2 md:order-1 w-full md:w-64 bg-gradient-to-b from-white via-gray-50 to-white border-t md:border-t-0 md:border-r border-gray-200 shadow-sm flex flex-row md:flex-col items-center justify-center md:justify-start p-4">
     <div className="flex flex-row md:flex-col items-center space-x-4 md:space-x-0 md:space-y-4">
-      <button
-        onClick={undo}
-        className="p-2 rounded-full text-gray-500 hover:text-blue-600 hover:bg-white shadow-sm transition-all duration-200"
-        aria-label="Annuler"
-      >
-        <Undo2 className="w-5 h-5" />
-      </button>
-      <button
-        onClick={redo}
-        className="p-2 rounded-full text-gray-500 hover:text-blue-600 hover:bg-white shadow-sm transition-all duration-200"
-        aria-label="Rétablir"
-      >
-        <Redo2 className="w-5 h-5" />
-      </button>
+      {/* Drawing Tools */}
+      <div className="flex flex-row md:flex-col items-center bg-gray-100 rounded-full p-1 shadow-inner space-x-2 md:space-x-0 md:space-y-2">
+        <button
+          onClick={toggleDrawing}
+          className={`px-5 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
+            drawingActive
+              ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
+              : 'text-gray-700 hover:bg-white hover:shadow-sm'
+          }`}
+        >
+          Rectangle
+        </button>
+        <button
+          onClick={togglePolygonDrawing}
+          className={`px-5 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
+            polygonActive
+              ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
+              : 'text-gray-700 hover:bg-white hover:shadow-sm'
+          }`}
+        >
+          Polygon
+        </button>
+        <button
+          onClick={toggleScaleMode}
+          className={`px-5 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
+            scaleActive
+              ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
+              : 'text-gray-700 hover:bg-white hover:shadow-sm'
+          }`}
+        >
+          <Ruler className="inline-block w-4 h-4 mr-1" />
+          Échelle
+        </button>
+      </div>
+
+      {/* Annotation Type Selector */}
+      <div className="flex items-center space-x-2 bg-white rounded-full px-4 py-2 shadow-md border border-gray-200">
+        <label className="text-sm font-medium text-gray-600">Type:</label>
+        <select
+          value={selectedEntity}
+          onChange={(e) => setSelectedEntity(e.target.value)}
+          className="border-0 bg-transparent text-sm font-medium text-gray-800 focus:outline-none cursor-pointer"
+        >
+          <option value="fenetre">Fenêtre</option>
+          <option value="porte">Porte</option>
+          <option value="facade">Façade</option>
+        </select>
+      </div>
     </div>
   </aside>
 );

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -1,107 +1,66 @@
 import React from 'react';
-import { Image as ImageIcon, Save, Ruler } from 'lucide-react';
+import { Image as ImageIcon, Save, Undo2, Redo2 } from 'lucide-react';
 
 const TopBar = ({
-  drawingActive,
-  polygonActive,
-  scaleActive,
-  toggleDrawing,
-  togglePolygonDrawing,
-  toggleScaleMode,
-  selectedEntity,
-  setSelectedEntity,
+  undo,
+  redo,
   exportAnnotations,
   handleImageUpload,
 }) => (
   <div className="relative bg-gradient-to-r from-white via-gray-50 to-white border-b border-gray-200 shadow-sm">
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between px-6 py-5 gap-4">
-      <div className="flex flex-col sm:flex-row sm:items-center sm:gap-6 gap-4">
-        {/* Title Section */}
-        <div className="flex items-center space-x-3">
-          <div className="w-3 h-3 bg-blue-500 rounded-full shadow-sm"></div>
-          <div>
-            <h1 className="text-xl font-bold text-gray-900 tracking-tight">
-              FACADE 1
-            </h1>
-            <span className="text-xs font-medium text-gray-400 uppercase tracking-wider">
-              Manuel
-            </span>
-          </div>
-        </div>
-        {/* Controls Section */}
-        <div className="flex flex-wrap items-center gap-3">
-          {/* Drawing Tools */}
-          <div className="flex items-center bg-gray-100 rounded-full p-1 shadow-inner">
-            <button
-              onClick={toggleDrawing}
-              className={`px-5 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
-                drawingActive
-                  ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
-                  : 'text-gray-700 hover:bg-white hover:shadow-sm'
-              }`}
-            >
-              Rectangle
-            </button>
-            <button
-              onClick={togglePolygonDrawing}
-              className={`px-5 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
-                polygonActive
-                  ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
-                  : 'text-gray-700 hover:bg-white hover:shadow-sm'
-              }`}
-            >
-              Polygon
-            </button>
-            <button
-              onClick={toggleScaleMode}
-              className={`px-5 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
-                scaleActive
-                  ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
-                  : 'text-gray-700 hover:bg-white hover:shadow-sm'
-              }`}
-            >
-              <Ruler className="inline-block w-4 h-4 mr-1" />
-              Échelle
-            </button>
-          </div>
-          {/* Image Upload */}
-          <input
-            type="file"
-            accept="image/*"
-            onChange={handleImageUpload}
-            id="image-upload"
-            className="hidden"
-          />
-          <label
-            htmlFor="image-upload"
-            className="px-5 py-2 rounded-full bg-white text-gray-700 font-medium text-sm shadow-md border border-gray-200 cursor-pointer hover:bg-gray-50 hover:shadow-lg transition-all duration-200 ease-out transform hover:scale-105"
-          >
-            <ImageIcon className="inline-block w-4 h-4 mr-2" />
-            Image
-          </label>
-          {/* Annotation Type Selector */}
-          <div className="flex items-center space-x-2 bg-white rounded-full px-4 py-2 shadow-md border border-gray-200">
-            <label className="text-sm font-medium text-gray-600">Type:</label>
-            <select
-              value={selectedEntity}
-              onChange={(e) => setSelectedEntity(e.target.value)}
-              className="border-0 bg-transparent text-sm font-medium text-gray-800 focus:outline-none cursor-pointer"
-            >
-              <option value="fenetre">Fenêtre</option>
-              <option value="porte">Porte</option>
-              <option value="facade">Façade</option>
-            </select>
-          </div>
+      {/* Title Section */}
+      <div className="flex items-center space-x-3">
+        <div className="w-3 h-3 bg-blue-500 rounded-full shadow-sm"></div>
+        <div>
+          <h1 className="text-xl font-bold text-gray-900 tracking-tight">FACADE 1</h1>
+          <span className="text-xs font-medium text-gray-400 uppercase tracking-wider">Manuel</span>
         </div>
       </div>
-      {/* Save Button */}
-      <button
-        onClick={exportAnnotations}
-        className="bg-gradient-to-r from-blue-500 to-blue-600 text-white px-6 py-2 rounded-full font-semibold text-sm shadow-lg hover:from-blue-600 hover:to-blue-700 hover:shadow-xl transition-all duration-200 ease-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-      >
-        <Save className="inline-block w-4 h-4 mr-2" />
-        Sauvegarder
-      </button>
+
+      {/* Controls */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Image Upload */}
+        <input
+          type="file"
+          accept="image/*"
+          onChange={handleImageUpload}
+          id="image-upload"
+          className="hidden"
+        />
+        <label
+          htmlFor="image-upload"
+          className="px-5 py-2 rounded-full bg-white text-gray-700 font-medium text-sm shadow-md border border-gray-200 cursor-pointer hover:bg-gray-50 hover:shadow-lg transition-all duration-200 ease-out transform hover:scale-105"
+        >
+          <ImageIcon className="inline-block w-4 h-4 mr-2" />
+          Image
+        </label>
+
+        {/* Undo / Redo */}
+        <button
+          onClick={undo}
+          className="p-2 rounded-full text-gray-500 hover:text-blue-600 hover:bg-white shadow-sm transition-all duration-200"
+          aria-label="Annuler"
+        >
+          <Undo2 className="w-5 h-5" />
+        </button>
+        <button
+          onClick={redo}
+          className="p-2 rounded-full text-gray-500 hover:text-blue-600 hover:bg-white shadow-sm transition-all duration-200"
+          aria-label="Rétablir"
+        >
+          <Redo2 className="w-5 h-5" />
+        </button>
+
+        {/* Save */}
+        <button
+          onClick={exportAnnotations}
+          className="bg-gradient-to-r from-blue-500 to-blue-600 text-white px-6 py-2 rounded-full font-semibold text-sm shadow-lg hover:from-blue-600 hover:to-blue-700 hover:shadow-xl transition-all duration-200 ease-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+        >
+          <Save className="inline-block w-4 h-4 mr-2" />
+          Sauvegarder
+        </button>
+      </div>
     </div>
     {/* Decorative Bottom Border */}
     <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-blue-200 to-transparent"></div>


### PR DESCRIPTION
## Summary
- Show image upload, undo/redo, and save actions in top bar
- Move drawing tools and annotation type selector into toolbox sidebar
- Update canvas to pass new props to updated components

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68960c5a85e08331a4607a73e670bb77