### PR TITLE
Export rectangles with polygon metrics

### DIFF
--- a/docs/BeginnersGuide.md
+++ b/docs/BeginnersGuide.md
@@ -83,6 +83,8 @@ l'utilisateur ferme la forme, l'aire est calculée via la **formule de la
 corde** ("shoelace formula") et le périmètre par la somme des distances entre
 points successifs (`Math.hypot`). Ces valeurs peuvent ensuite être utilisées
 pour afficher des mesures précises.
+Les rectangles sont eux aussi exportés comme des polygones ; leur aire et leur
+périmètre sont donc calculés de la même manière.
 
 ### Conversion géographique
 La fonction `pixelToGeo` effectue une interpolation linéaire entre les

--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -514,10 +514,10 @@ const toggleScaleMode = () => {
           pixelToGeo(left, top, imgWidth, imgHeight)
         ];
         if (scaleRatio) {
+          const perimeterPx = 2 * (width + height);
           metrics = {
-            width_cm: width * scaleRatio,
-            height_cm: height * scaleRatio,
-            area_cm2: width * scaleRatio * height * scaleRatio,
+            area_cm2: width * height * scaleRatio * scaleRatio,
+            perimeter_cm: perimeterPx * scaleRatio,
           };
         }
       } else if (obj.type === 'polygon') {


### PR DESCRIPTION
## Summary
- compute rectangle annotations as polygons with area & perimeter
- clarify docs that rectangles are exported like polygons

## Testing
- `npm test` *(fails: The module '/workspace/facade-new/node_modules/canvas/build/Release/canvas.node' was compiled against a different Node.js version using NODE_MODULE_VERSION 115. This version of Node.js requires NODE_MODULE_VERSION 127)*

------
https://chatgpt.com/codex/tasks/task_e_68961f2d78308331b3e9765ffdbe5998