### PR TITLE
Add rectangle dropdown for entity selection

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 const Sidebar = ({ selectedEntity, setSelectedEntity, drawingActive, polygonActive, toggleDrawing, togglePolygonDrawing, exportAnnotations }) => {
   const [showPolygonDropdown, setShowPolygonDropdown] = useState(false);
+  const [showRectangleDropdown, setShowRectangleDropdown] = useState(false);
 
   const handlePolygonClick = () => {
     if (polygonActive) {
@@ -11,10 +12,24 @@ const Sidebar = ({ selectedEntity, setSelectedEntity, drawingActive, polygonActi
     }
   };
 
+  const handleRectangleClick = () => {
+    if (drawingActive) {
+      toggleDrawing();
+    } else {
+      setShowRectangleDropdown((prev) => !prev);
+    }
+  };
+
   const startPolygonWithType = (type) => {
     setSelectedEntity(type);
     setShowPolygonDropdown(false);
     togglePolygonDrawing();
+  };
+
+  const startRectangleWithType = (type) => {
+    setSelectedEntity(type);
+    setShowRectangleDropdown(false);
+    toggleDrawing();
   };
 
   return (
@@ -23,12 +38,36 @@ const Sidebar = ({ selectedEntity, setSelectedEntity, drawingActive, polygonActi
         <h3 className="text-white mb-4 text-lg font-bold">FACADE 1 (MANUAL)</h3>
 
         <div className="flex gap-2 mb-4">
-          <button
-            onClick={toggleDrawing}
-            className={`flex-1 p-2 rounded text-white text-xs ${drawingActive ? 'bg-blue-500' : 'bg-gray-600'}`}
-          >
-            {drawingActive ? 'Stop Rectangle' : 'Rectangle'}
-          </button>
+          <div className="relative flex-1">
+            <button
+              onClick={handleRectangleClick}
+              className={`w-full p-2 rounded text-white text-xs ${drawingActive ? 'bg-blue-500' : 'bg-gray-600'}`}
+            >
+              {drawingActive ? 'Stop Rectangle' : 'Rectangle'}
+            </button>
+            {showRectangleDropdown && !drawingActive && (
+              <div className="absolute left-0 mt-1 w-full bg-gray-800 border border-gray-600 rounded z-10">
+                <button
+                  className="block w-full text-left px-2 py-1 text-white text-xs hover:bg-gray-700"
+                  onClick={() => startRectangleWithType('fenetre')}
+                >
+                  🪟 Fenêtre
+                </button>
+                <button
+                  className="block w-full text-left px-2 py-1 text-white text-xs hover:bg-gray-700"
+                  onClick={() => startRectangleWithType('porte')}
+                >
+                  🚪 Porte
+                </button>
+                <button
+                  className="block w-full text-left px-2 py-1 text-white text-xs hover:bg-gray-700"
+                  onClick={() => startRectangleWithType('facade')}
+                >
+                  🏢 Façade
+                </button>
+              </div>
+            )}
+          </div>
           <div className="relative flex-1">
             <button
               onClick={handlePolygonClick}

--- a/src/components/Toolbox.js
+++ b/src/components/Toolbox.js
@@ -12,6 +12,7 @@ const Toolbox = ({
   setSelectedEntity,
 }) => {
   const [showPolygonDropdown, setShowPolygonDropdown] = useState(false);
+  const [showRectangleDropdown, setShowRectangleDropdown] = useState(false);
 
   const handlePolygonClick = () => {
     if (polygonActive) {
@@ -21,10 +22,24 @@ const Toolbox = ({
     }
   };
 
+  const handleRectangleClick = () => {
+    if (drawingActive) {
+      toggleDrawing();
+    } else {
+      setShowRectangleDropdown((prev) => !prev);
+    }
+  };
+
   const startPolygonWithType = (type) => {
     setSelectedEntity(type);
     setShowPolygonDropdown(false);
     togglePolygonDrawing();
+  };
+
+  const startRectangleWithType = (type) => {
+    setSelectedEntity(type);
+    setShowRectangleDropdown(false);
+    toggleDrawing();
   };
 
   return (
@@ -32,16 +47,40 @@ const Toolbox = ({
       <div className="flex flex-row md:flex-col items-center space-x-4 md:space-x-0 md:space-y-4">
         {/* Drawing Tools */}
         <div className="flex flex-row md:flex-col items-center bg-gray-100 rounded-full p-1 shadow-inner space-x-2 md:space-x-0 md:space-y-2">
-          <button
-            onClick={toggleDrawing}
-            className={`px-5 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
-              drawingActive
-                ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
-                : 'text-gray-700 hover:bg-white hover:shadow-sm'
-            }`}
-          >
-            Rectangle
-          </button>
+          <div className="relative">
+            <button
+              onClick={handleRectangleClick}
+              className={`px-5 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
+                drawingActive
+                  ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
+                  : 'text-gray-700 hover:bg-white hover:shadow-sm'
+              }`}
+            >
+              Rectangle
+            </button>
+            {showRectangleDropdown && !drawingActive && (
+              <div className="absolute left-0 mt-2 w-32 bg-white border border-gray-200 rounded shadow-lg z-10">
+                <button
+                  className="block w-full text-left px-3 py-1 text-sm text-gray-700 hover:bg-gray-100"
+                  onClick={() => startRectangleWithType('fenetre')}
+                >
+                  Fenêtre
+                </button>
+                <button
+                  className="block w-full text-left px-3 py-1 text-sm text-gray-700 hover:bg-gray-100"
+                  onClick={() => startRectangleWithType('porte')}
+                >
+                  Porte
+                </button>
+                <button
+                  className="block w-full text-left px-3 py-1 text-sm text-gray-700 hover:bg-gray-100"
+                  onClick={() => startRectangleWithType('facade')}
+                >
+                  Façade
+                </button>
+              </div>
+            )}
+          </div>
           <div className="relative">
             <button
               onClick={handlePolygonClick}


### PR DESCRIPTION
## Summary
- add dropdown to rectangle tool for choosing entity type
- mirror dropdown in sidebar rectangle control

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689924ed97ac8331bba9f097b6adb751