### PR TITLE
Fix side panel layout to avoid scrolling

### DIFF
--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -217,10 +217,16 @@ const AnnotationCanvas = () => {
     });
     fabricRef.current = canvas;
 
-    canvas.setWidth(800);
-    canvas.setHeight(600);
+    const resizeCanvas = () => {
+      const parent = canvasRef.current.parentElement;
+      canvas.setWidth(parent.clientWidth);
+      canvas.setHeight(parent.clientHeight);
+      canvas.renderAll();
+    };
 
-    
+    resizeCanvas();
+    window.addEventListener('resize', resizeCanvas);
+
     canvas.on('mouse:down', function (opt) {
       const pointer = canvas.getPointer(opt.e);
       if (isScaleMode.current) {
@@ -411,7 +417,10 @@ const AnnotationCanvas = () => {
       canvas.renderAll();
     });
 
-    return () => canvas.dispose();
+    return () => {
+      window.removeEventListener('resize', resizeCanvas);
+      canvas.dispose();
+    };
   }, []);
 
   const toggleDrawing = () => {
@@ -706,8 +715,8 @@ const toggleScaleMode = () => {
 
 
   return (
-    <div className="relative flex flex-col md:flex-row h-screen bg-gray-50">
-      <main className="flex-1 flex flex-col order-1 md:order-2">
+    <div className="relative flex flex-row h-screen bg-gray-50">
+      <main className="flex-1 flex flex-col order-2">
         <TopBar
           undo={undo}
           redo={redo}
@@ -715,10 +724,10 @@ const toggleScaleMode = () => {
           handleImageUpload={handleImageUpload}
         />
 
-        <div className="flex-1 p-2 md:p-6 flex items-center justify-center">
-          <CanvasWithGrid ref={canvasRef} width={1600} height={900} />
-        </div>
-      </main>
+          <div className="flex-1 p-2 md:p-6 flex items-center justify-center h-full">
+            <CanvasWithGrid ref={canvasRef} width="100%" height="100%" />
+          </div>
+        </main>
 
       <Toolbox
         drawingActive={drawingActive}

--- a/src/components/LayerPanel.js
+++ b/src/components/LayerPanel.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const LayerPanel = ({ layerVisibility, toggleLayer }) => (
-  <aside className="order-3 md:order-3 w-full md:w-64 bg-gradient-to-b from-white via-gray-50 to-white border-t md:border-t-0 md:border-l border-gray-200 shadow-sm p-4">
+  <aside className="order-3 w-64 bg-gradient-to-b from-white via-gray-50 to-white border-l border-gray-200 shadow-sm p-4">
     <div className="flex flex-col space-y-3 text-sm text-gray-700">
       <span className="font-semibold text-gray-800">Calques</span>
       {[

--- a/src/components/Toolbox.js
+++ b/src/components/Toolbox.js
@@ -43,10 +43,10 @@ const Toolbox = ({
   };
 
   return (
-    <aside className="order-2 md:order-1 w-full md:w-64 bg-gradient-to-b from-white via-gray-50 to-white border-t md:border-t-0 md:border-r border-gray-200 shadow-sm flex flex-row md:flex-col items-center justify-center md:justify-start p-4">
-      <div className="flex flex-row md:flex-col items-center space-x-4 md:space-x-0 md:space-y-4">
-        {/* Drawing Tools */}
-        <div className="flex flex-row md:flex-col items-center bg-gray-100 rounded-full p-1 shadow-inner space-x-2 md:space-x-0 md:space-y-2">
+    <aside className="order-1 w-64 bg-gradient-to-b from-white via-gray-50 to-white border-r border-gray-200 shadow-sm flex flex-col items-center justify-start p-4">
+        <div className="flex flex-col items-center space-y-4">
+          {/* Drawing Tools */}
+          <div className="flex flex-col items-center bg-gray-100 rounded-full p-1 shadow-inner space-y-2">
           <div className="relative">
             <button
               onClick={handleRectangleClick}


### PR DESCRIPTION
## Summary
- resize Fabric canvas to fill available space and update on window resize
- let CanvasWithGrid occupy full width and height so side panels stay visible

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899329e44408331ba812e37f9f3c4b2