### PR TITLE
Ensure top bar spans entire width

### DIFF
--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -715,35 +715,38 @@ const toggleScaleMode = () => {
 
 
   return (
-    <div className="relative flex flex-row h-screen bg-gray-50">
-      <main className="flex-1 flex flex-col order-2">
-        <TopBar
-          undo={undo}
-          redo={redo}
-          exportAnnotations={exportAnnotations}
-          handleImageUpload={handleImageUpload}
+    <div className="relative flex flex-col h-screen bg-gray-50">
+      <TopBar
+        undo={undo}
+        redo={redo}
+        exportAnnotations={exportAnnotations}
+        handleImageUpload={handleImageUpload}
+      />
+
+      <div className="flex flex-1">
+        <Toolbox
+          drawingActive={drawingActive}
+          polygonActive={polygonActive}
+          scaleActive={scaleActive}
+          toggleDrawing={toggleDrawing}
+          togglePolygonDrawing={togglePolygonDrawing}
+          toggleScaleMode={toggleScaleMode}
+          selectedEntity={selectedEntity}
+          setSelectedEntity={setSelectedEntity}
         />
 
+        <main className="flex-1 flex flex-col">
           <div className="flex-1 p-2 md:p-6 flex items-center justify-center h-full">
             <CanvasWithGrid ref={canvasRef} width="100%" height="100%" />
           </div>
         </main>
 
-      <Toolbox
-        drawingActive={drawingActive}
-        polygonActive={polygonActive}
-        scaleActive={scaleActive}
-        toggleDrawing={toggleDrawing}
-        togglePolygonDrawing={togglePolygonDrawing}
-        toggleScaleMode={toggleScaleMode}
-        selectedEntity={selectedEntity}
-        setSelectedEntity={setSelectedEntity}
-      />
+        <LayerPanel
+          layerVisibility={layerVisibility}
+          toggleLayer={toggleLayer}
+        />
+      </div>
 
-      <LayerPanel
-        layerVisibility={layerVisibility}
-        toggleLayer={toggleLayer}
-      />
       <ScaleModal
         isOpen={scaleModalOpen}
         onSubmit={(cm) => {

--- a/src/components/LayerPanel.js
+++ b/src/components/LayerPanel.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const LayerPanel = ({ layerVisibility, toggleLayer }) => (
-  <aside className="order-3 w-64 bg-gradient-to-b from-white via-gray-50 to-white border-l border-gray-200 shadow-sm p-4">
+  <aside className="w-64 bg-gradient-to-b from-white via-gray-50 to-white border-l border-gray-200 shadow-sm p-4">
     <div className="flex flex-col space-y-3 text-sm text-gray-700">
       <span className="font-semibold text-gray-800">Calques</span>
       {[

--- a/src/components/Toolbox.js
+++ b/src/components/Toolbox.js
@@ -43,7 +43,7 @@ const Toolbox = ({
   };
 
   return (
-    <aside className="order-1 w-64 bg-gradient-to-b from-white via-gray-50 to-white border-r border-gray-200 shadow-sm flex flex-col items-center justify-start p-4">
+    <aside className="w-64 bg-gradient-to-b from-white via-gray-50 to-white border-r border-gray-200 shadow-sm flex flex-col items-center justify-start p-4">
         <div className="flex flex-col items-center space-y-4">
           {/* Drawing Tools */}
           <div className="flex flex-col items-center bg-gray-100 rounded-full p-1 shadow-inner space-y-2">

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -7,7 +7,7 @@ const TopBar = ({
   exportAnnotations,
   handleImageUpload,
 }) => (
-  <div className="relative bg-gradient-to-r from-white via-gray-50 to-white border-b border-gray-200 shadow-sm">
+  <div className="relative w-full bg-gradient-to-r from-white via-gray-50 to-white border-b border-gray-200 shadow-sm">
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between px-6 py-5 gap-4">
       {/* Title Section */}
       <div className="flex items-center space-x-3">


### PR DESCRIPTION
## Summary
- Restructure annotation layout so the top bar spans the full width and side panels sit underneath
- Remove ordering from Toolbox and LayerPanel for predictable placement

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6899c7181824833183ec7d094e62115c