### PR TITLE
fix: center and scale image reliably

### DIFF
--- a/src/components/CanvasWithGrid.js
+++ b/src/components/CanvasWithGrid.js
@@ -1,29 +1,46 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useEffect, useRef } from 'react';
 
 // Renders a Fabric canvas overlaid with a configurable grid. The grid is
 // produced via CSS gradients (no loops or canvas drawing), repeated every
 // `gridSize` pixels.
 const CanvasWithGrid = forwardRef(
   (
-    { className = '', width = 800, height = 600, gridSize = 20 },
+    { className = '', width = 800, height = 600, gridSize = 20, onResize },
     ref
   ) => {
-  return (
-    <div
-      className={`bg-gray-100 border rounded-lg relative ${className}`}
-      style={{ width, height }}
-    >
+    const containerRef = useRef(null);
+
+    useEffect(() => {
+      if (
+        !onResize ||
+        !containerRef.current ||
+        typeof ResizeObserver === 'undefined'
+      )
+        return;
+      const observer = new ResizeObserver(() => {
+        onResize();
+      });
+      observer.observe(containerRef.current);
+      return () => observer.disconnect();
+    }, [onResize]);
+
+    return (
       <div
-        className="absolute inset-0 pointer-events-none"
-        style={{
-          backgroundSize: `${gridSize}px ${gridSize}px`,
-          backgroundImage:
-            'linear-gradient(to right, rgba(0,0,0,0.1) 1px, transparent 1px), linear-gradient(to bottom, rgba(0,0,0,0.1) 1px, transparent 1px)'
-        }}
-      />
-      <canvas ref={ref} className="w-full h-full" />
-    </div>
-  );
+        ref={containerRef}
+        className={`bg-gray-100 border rounded-lg relative ${className}`}
+        style={{ width, height }}
+      >
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            backgroundSize: `${gridSize}px ${gridSize}px`,
+            backgroundImage:
+              'linear-gradient(to right, rgba(0,0,0,0.1) 1px, transparent 1px), linear-gradient(to bottom, rgba(0,0,0,0.1) 1px, transparent 1px)'
+          }}
+        />
+        <canvas ref={ref} className="w-full h-full" />
+      </div>
+    );
   }
 );
 


### PR DESCRIPTION
## Summary
- watch CanvasWithGrid container with ResizeObserver to trigger resize callbacks
- centralize canvas sizing logic and wire to container resize for consistent image scaling
- define standalone resize handler and clean up event listener to satisfy hook rules

## Testing
- `npm test -- --watchAll=false` *(fails: module '/workspace/facade-new/node_modules/canvas/build/Release/canvas.node' was compiled against a different Node.js version)*

------
https://chatgpt.com/codex/tasks/task_e_689a01393bdc8331ad3a5c7aeb7d17b8