### PR TITLE
Disable tools until scale is set

### DIFF
--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -32,6 +32,7 @@ const AnnotationCanvas = () => {
   const [scaleRatio, setScaleRatio] = useState(null);
   const [scaleModalOpen, setScaleModalOpen] = useState(false);
   const [pendingScaleLength, setPendingScaleLength] = useState(null);
+  const scaleSet = scaleRatio !== null;
   const currentPolygonPoints = useRef([]);
   const currentPolygonLines = useRef([]);
   const currentPolygonCircles = useRef([]);
@@ -714,6 +715,7 @@ ref.current = fabricImg;
     <div className="relative flex flex-col md:flex-row h-screen bg-gray-50">
       <main className="flex-1 flex flex-col order-1 md:order-2">
         <TopBar
+        scaleSet={scaleSet}
           undo={undo}
           redo={redo}
           exportAnnotations={exportAnnotations}
@@ -726,6 +728,7 @@ ref.current = fabricImg;
       </main>
 
  <Toolbox
+        scaleSet={scaleSet}
         drawingActive={drawingActive}
         polygonActive={polygonActive}
         scaleActive={scaleActive}
@@ -737,9 +740,11 @@ ref.current = fabricImg;
       />
 
       <LayerPanel
+        scaleSet={scaleSet}
         layerVisibility={layerVisibility}
         toggleLayer={toggleLayer}
-      />      <ScaleModal
+      />
+      <ScaleModal
         isOpen={scaleModalOpen}
         onSubmit={(cm) => {
           if (pendingScaleLength) {

--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -723,7 +723,7 @@ ref.current = fabricImg;
         />
 
         <div className="flex-1 p-2 md:p-6 flex items-center justify-center">
-          <CanvasWithGrid ref={canvasRef} width={1200} height={600}  gridSize={400}/>
+          <CanvasWithGrid ref={canvasRef}  />
         </div>
       </main>
 

--- a/src/components/CanvasWithGrid.js
+++ b/src/components/CanvasWithGrid.js
@@ -1,10 +1,10 @@
 import React, { forwardRef ,useEffect, useRef} from 'react';
 
-const CanvasWithGrid = forwardRef(({ className = '', width = 800, height = 600 }, ref) => {
+const CanvasWithGrid = forwardRef(({ className = '' }, ref) => {
   return (
     <div
       className={`bg-gray-100 border rounded-lg relative ${className}`}
-      style={{ width, height }}
+     
     >
       <div
         className="absolute inset-0 pointer-events-none"

--- a/src/components/LayerPanel.js
+++ b/src/components/LayerPanel.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const LayerPanel = ({ layerVisibility, toggleLayer }) => (
+const LayerPanel = ({ layerVisibility, toggleLayer, scaleSet }) => (
   <aside className="w-64 bg-gradient-to-b from-white via-gray-50 to-white border-l border-gray-200 shadow-sm p-4">
     <div className="flex flex-col space-y-3 text-sm text-gray-700">
       <span className="font-semibold text-gray-800">Calques</span>
@@ -12,11 +12,12 @@ const LayerPanel = ({ layerVisibility, toggleLayer }) => (
       ].map(({ key, label }) => (
         <label
           key={key}
-          className="flex items-center space-x-2 px-2 py-1 rounded hover:bg-gray-100"
+          className={`flex items-center space-x-2 px-2 py-1 rounded hover:bg-gray-100 ${!scaleSet ? 'opacity-50 cursor-not-allowed' : ''}`}
         >
           <input
             type="checkbox"
-            className="form-checkbox h-4 w-4 text-blue-600 rounded focus:ring-blue-500"
+            className="form-checkbox h-4 w-4 text-blue-600 rounded focus:ring-blue-500 disabled:opacity-50"
+            disabled={!scaleSet}
             checked={layerVisibility[key]}
             onChange={() => toggleLayer(key)}
           />

--- a/src/components/Toolbox.js
+++ b/src/components/Toolbox.js
@@ -10,11 +10,13 @@ const Toolbox = ({
   toggleScaleMode,
   selectedEntity,
   setSelectedEntity,
+  scaleSet,
 }) => {
   const [showPolygonDropdown, setShowPolygonDropdown] = useState(false);
   const [showRectangleDropdown, setShowRectangleDropdown] = useState(false);
 
   const handlePolygonClick = () => {
+    if (!scaleSet) return;
     if (polygonActive) {
       togglePolygonDrawing();
     } else {
@@ -23,6 +25,7 @@ const Toolbox = ({
   };
 
   const handleRectangleClick = () => {
+    if (!scaleSet) return;
     if (drawingActive) {
       toggleDrawing();
     } else {
@@ -50,11 +53,12 @@ const Toolbox = ({
           <div className="relative">
             <button
               onClick={handleRectangleClick}
+              disabled={!scaleSet}
               className={`flex items-center gap-2 px-4 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
                 drawingActive
                   ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
                   : 'bg-white text-gray-700 hover:bg-gray-50 hover:shadow-sm'
-              }`}
+              } ${!scaleSet ? 'opacity-50 cursor-not-allowed' : ''}`}
             >
               <Square className="w-4 h-4" />
               <span>Rectangle</span>
@@ -85,11 +89,12 @@ const Toolbox = ({
           <div className="relative">
             <button
               onClick={handlePolygonClick}
+              disabled={!scaleSet}
               className={`flex items-center gap-2 px-4 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
                 polygonActive
                   ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
                   : 'bg-white text-gray-700 hover:bg-gray-50 hover:shadow-sm'
-              }`}
+              } ${!scaleSet ? 'opacity-50 cursor-not-allowed' : ''}`}
             >
               <Shapes className="w-4 h-4" />
               <span>Polygon</span>
@@ -123,7 +128,7 @@ const Toolbox = ({
               scaleActive
                 ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
                 : 'bg-white text-gray-700 hover:bg-gray-50 hover:shadow-sm'
-            }`}
+              } ${!scaleSet ? 'opacity-50 cursor-not-allowed' : ''}`}
           >
             <Ruler className="w-4 h-4" />
             <span>Échelle</span>

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -7,6 +7,7 @@ const TopBar = ({
   exportAnnotations,
   handleImageUpload,
   deleteSelected,
+  scaleSet,
 }) => (
   <div className="relative w-full bg-gradient-to-r from-white via-gray-50 to-white border-b border-gray-200 shadow-sm">
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between px-6 py-5 gap-4">
@@ -65,7 +66,8 @@ const TopBar = ({
         {/* Save */}
         <button
           onClick={exportAnnotations}
-          className="bg-gradient-to-r from-blue-500 to-blue-600 text-white px-6 py-2 rounded-full font-semibold text-sm shadow-lg hover:from-blue-600 hover:to-blue-700 hover:shadow-xl transition-all duration-200 ease-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          disabled={!scaleSet}
+          className={`bg-gradient-to-r from-blue-500 to-blue-600 text-white px-6 py-2 rounded-full font-semibold text-sm shadow-lg hover:from-blue-600 hover:to-blue-700 hover:shadow-xl transition-all duration-200 ease-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${!scaleSet ? 'opacity-50 cursor-not-allowed' : ''}`}
         >
           <Save className="inline-block w-4 h-4 mr-2" />
           Sauvegarder


### PR DESCRIPTION
## Summary
- Track whether a scale has been defined and pass this flag to child components
- Disable polygon/rectangle drawing, layer toggles, and saving when no scale is selected

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689cb1d797808331a89c82f56b3490e5