### PR TITLE
Refine layout and enable all controls

### DIFF
--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -32,7 +32,6 @@ const AnnotationCanvas = () => {
   const [scaleRatio, setScaleRatio] = useState(null);
   const [scaleModalOpen, setScaleModalOpen] = useState(false);
   const [pendingScaleLength, setPendingScaleLength] = useState(null);
-  const scaleSet = scaleRatio !== null;
   const currentPolygonPoints = useRef([]);
   const currentPolygonLines = useRef([]);
   const currentPolygonCircles = useRef([]);
@@ -157,6 +156,22 @@ const [layerVisibility, setLayerVisibility] = useState({
       annotationsHistory.current.push(annotation);
       canvas.renderAll();
     }
+  };
+
+  const deleteSelected = () => {
+    const canvas = fabricRef.current;
+    if (!canvas) return;
+    const activeObjects = canvas.getActiveObjects();
+    if (!activeObjects.length) return;
+    activeObjects.forEach((obj) => {
+      canvas.remove(obj);
+      const index = annotationsHistory.current.indexOf(obj);
+      if (index !== -1) {
+        annotationsHistory.current.splice(index, 1);
+      }
+    });
+    canvas.discardActiveObject();
+    canvas.requestRenderAll();
   };
  // Allow keyboard shortcuts (Ctrl/Cmd + Z or Y) to trigger undo/redo
   useEffect(() => {
@@ -712,38 +727,33 @@ ref.current = fabricImg;
 
 
   return (
-    <div className="relative flex flex-col md:flex-row h-screen bg-gray-50">
-      <main className="flex-1 flex flex-col order-1 md:order-2">
-        <TopBar
-        scaleSet={scaleSet}
-          undo={undo}
-          redo={redo}
-          exportAnnotations={exportAnnotations}
-          handleImageUpload={handleImageUpload}
+    <div className="flex flex-col h-screen bg-gray-50">
+      <TopBar
+        undo={undo}
+        redo={redo}
+        exportAnnotations={exportAnnotations}
+        handleImageUpload={handleImageUpload}
+        deleteSelected={deleteSelected}
+      />
+      <div className="flex flex-1">
+        <Toolbox
+          drawingActive={drawingActive}
+          polygonActive={polygonActive}
+          scaleActive={scaleActive}
+          toggleDrawing={toggleDrawing}
+          togglePolygonDrawing={togglePolygonDrawing}
+          toggleScaleMode={toggleScaleMode}
+          selectedEntity={selectedEntity}
+          setSelectedEntity={setSelectedEntity}
         />
-
         <div className="flex-1 p-2 md:p-6 flex items-center justify-center">
-          <CanvasWithGrid ref={canvasRef}  />
+          <CanvasWithGrid ref={canvasRef} />
         </div>
-      </main>
-
- <Toolbox
-        scaleSet={scaleSet}
-        drawingActive={drawingActive}
-        polygonActive={polygonActive}
-        scaleActive={scaleActive}
-        toggleDrawing={toggleDrawing}
-        togglePolygonDrawing={togglePolygonDrawing}
-        toggleScaleMode={toggleScaleMode}
-        selectedEntity={selectedEntity}
-        setSelectedEntity={setSelectedEntity}
-      />
-
-      <LayerPanel
-        scaleSet={scaleSet}
-        layerVisibility={layerVisibility}
-        toggleLayer={toggleLayer}
-      />
+        <LayerPanel
+          layerVisibility={layerVisibility}
+          toggleLayer={toggleLayer}
+        />
+      </div>
       <ScaleModal
         isOpen={scaleModalOpen}
         onSubmit={(cm) => {

--- a/src/components/LayerPanel.js
+++ b/src/components/LayerPanel.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const LayerPanel = ({ layerVisibility, toggleLayer, scaleSet }) => (
+const LayerPanel = ({ layerVisibility, toggleLayer }) => (
   <aside className="w-64 bg-gradient-to-b from-white via-gray-50 to-white border-l border-gray-200 shadow-sm p-4">
     <div className="flex flex-col space-y-3 text-sm text-gray-700">
       <span className="font-semibold text-gray-800">Calques</span>
@@ -12,12 +12,11 @@ const LayerPanel = ({ layerVisibility, toggleLayer, scaleSet }) => (
       ].map(({ key, label }) => (
         <label
           key={key}
-          className={`flex items-center space-x-2 px-2 py-1 rounded hover:bg-gray-100 ${!scaleSet ? 'opacity-50 cursor-not-allowed' : ''}`}
+          className="flex items-center space-x-2 px-2 py-1 rounded hover:bg-gray-100"
         >
           <input
             type="checkbox"
-            className="form-checkbox h-4 w-4 text-blue-600 rounded focus:ring-blue-500 disabled:opacity-50"
-            disabled={!scaleSet}
+            className="form-checkbox h-4 w-4 text-blue-600 rounded focus:ring-blue-500"
             checked={layerVisibility[key]}
             onChange={() => toggleLayer(key)}
           />

--- a/src/components/Toolbox.js
+++ b/src/components/Toolbox.js
@@ -10,13 +10,11 @@ const Toolbox = ({
   toggleScaleMode,
   selectedEntity,
   setSelectedEntity,
-  scaleSet,
 }) => {
   const [showPolygonDropdown, setShowPolygonDropdown] = useState(false);
   const [showRectangleDropdown, setShowRectangleDropdown] = useState(false);
 
   const handlePolygonClick = () => {
-    if (!scaleSet) return;
     if (polygonActive) {
       togglePolygonDrawing();
     } else {
@@ -25,7 +23,6 @@ const Toolbox = ({
   };
 
   const handleRectangleClick = () => {
-    if (!scaleSet) return;
     if (drawingActive) {
       toggleDrawing();
     } else {
@@ -53,12 +50,11 @@ const Toolbox = ({
           <div className="relative">
             <button
               onClick={handleRectangleClick}
-              disabled={!scaleSet}
               className={`flex items-center gap-2 px-4 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
                 drawingActive
                   ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
                   : 'bg-white text-gray-700 hover:bg-gray-50 hover:shadow-sm'
-              } ${!scaleSet ? 'opacity-50 cursor-not-allowed' : ''}`}
+              }`}
             >
               <Square className="w-4 h-4" />
               <span>Rectangle</span>
@@ -89,12 +85,11 @@ const Toolbox = ({
           <div className="relative">
             <button
               onClick={handlePolygonClick}
-              disabled={!scaleSet}
               className={`flex items-center gap-2 px-4 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
                 polygonActive
                   ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
                   : 'bg-white text-gray-700 hover:bg-gray-50 hover:shadow-sm'
-              } ${!scaleSet ? 'opacity-50 cursor-not-allowed' : ''}`}
+              }`}
             >
               <Shapes className="w-4 h-4" />
               <span>Polygon</span>
@@ -128,7 +123,7 @@ const Toolbox = ({
               scaleActive
                 ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
                 : 'bg-white text-gray-700 hover:bg-gray-50 hover:shadow-sm'
-              } ${!scaleSet ? 'opacity-50 cursor-not-allowed' : ''}`}
+              }`}
           >
             <Ruler className="w-4 h-4" />
             <span>Échelle</span>

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -7,7 +7,6 @@ const TopBar = ({
   exportAnnotations,
   handleImageUpload,
   deleteSelected,
-  scaleSet,
 }) => (
   <div className="relative w-full bg-gradient-to-r from-white via-gray-50 to-white border-b border-gray-200 shadow-sm">
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between px-6 py-5 gap-4">
@@ -66,8 +65,7 @@ const TopBar = ({
         {/* Save */}
         <button
           onClick={exportAnnotations}
-          disabled={!scaleSet}
-          className={`bg-gradient-to-r from-blue-500 to-blue-600 text-white px-6 py-2 rounded-full font-semibold text-sm shadow-lg hover:from-blue-600 hover:to-blue-700 hover:shadow-xl transition-all duration-200 ease-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${!scaleSet ? 'opacity-50 cursor-not-allowed' : ''}`}
+          className="bg-gradient-to-r from-blue-500 to-blue-600 text-white px-6 py-2 rounded-full font-semibold text-sm shadow-lg hover:from-blue-600 hover:to-blue-700 hover:shadow-xl transition-all duration-200 ease-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
         >
           <Save className="inline-block w-4 h-4 mr-2" />
           Sauvegarder


### PR DESCRIPTION
## Summary
- Keep save and drawing tools active at all times by removing scale-based disables
- Move layer panel to the right and let top bar span full width
- Simplify components for always-on interactions

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a39a59a40c833183498820b225eddf