### PR TITLE
Disable drawing and layer controls until image is scaled

### DIFF
--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -718,13 +718,13 @@ ref.current = fabricImg;
   // Ajoute l'image sélectionnée sans appliquer de crop
   const addImageDirectly = () => {
     if (!selectedImage) return;
-    
+
     addImageToCanvas(selectedImage, { layer: 'baseImage' });
 
     setCropMode(null);
     setSelectedImage(null);
   };
-
+  const toolsEnabled = scaleRatio !== null;
 
   return (
     <div className="flex flex-col h-screen bg-gray-50">
@@ -745,13 +745,20 @@ ref.current = fabricImg;
           toggleScaleMode={toggleScaleMode}
           selectedEntity={selectedEntity}
           setSelectedEntity={setSelectedEntity}
+          disabled={!toolsEnabled}
         />
-        <div className="flex-1 p-2 md:p-6 flex items-center justify-center">
+        <div className="flex-1 p-2 md:p-6 flex items-center justify-center relative">
           <CanvasWithGrid ref={canvasRef} />
+          {!toolsEnabled && (
+            <div className="absolute top-4 left-1/2 transform -translate-x-1/2 bg-yellow-100 text-yellow-800 px-4 py-2 rounded shadow">
+              Veuillez mettre à l'échelle l'image d'abord
+            </div>
+          )}
         </div>
         <LayerPanel
           layerVisibility={layerVisibility}
           toggleLayer={toggleLayer}
+          disabled={!toolsEnabled}
         />
       </div>
       <ScaleModal

--- a/src/components/LayerPanel.js
+++ b/src/components/LayerPanel.js
@@ -1,7 +1,11 @@
 import React from 'react';
 
-const LayerPanel = ({ layerVisibility, toggleLayer }) => (
-  <aside className="w-64 bg-gradient-to-b from-white via-gray-50 to-white border-l border-gray-200 shadow-sm p-4">
+const LayerPanel = ({ layerVisibility, toggleLayer, disabled }) => (
+  <aside
+    className={`w-64 bg-gradient-to-b from-white via-gray-50 to-white border-l border-gray-200 shadow-sm p-4 ${
+      disabled ? 'opacity-50 pointer-events-none' : ''
+    }`}
+  >
     <div className="flex flex-col space-y-3 text-sm text-gray-700">
       <span className="font-semibold text-gray-800">Calques</span>
       {[
@@ -19,6 +23,7 @@ const LayerPanel = ({ layerVisibility, toggleLayer }) => (
             className="form-checkbox h-4 w-4 text-blue-600 rounded focus:ring-blue-500"
             checked={layerVisibility[key]}
             onChange={() => toggleLayer(key)}
+            disabled={disabled}
           />
           <span>{label}</span>
         </label>

--- a/src/components/Toolbox.js
+++ b/src/components/Toolbox.js
@@ -10,11 +10,13 @@ const Toolbox = ({
   toggleScaleMode,
   selectedEntity,
   setSelectedEntity,
+  disabled,
 }) => {
   const [showPolygonDropdown, setShowPolygonDropdown] = useState(false);
   const [showRectangleDropdown, setShowRectangleDropdown] = useState(false);
 
   const handlePolygonClick = () => {
+    if (disabled) return;
     if (polygonActive) {
       togglePolygonDrawing();
     } else {
@@ -23,6 +25,7 @@ const Toolbox = ({
   };
 
   const handleRectangleClick = () => {
+    if (disabled) return;
     if (drawingActive) {
       toggleDrawing();
     } else {
@@ -50,16 +53,19 @@ const Toolbox = ({
           <div className="relative">
             <button
               onClick={handleRectangleClick}
+              disabled={disabled}
               className={`flex items-center gap-2 px-4 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
-                drawingActive
-                  ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
-                  : 'bg-white text-gray-700 hover:bg-gray-50 hover:shadow-sm'
+                disabled
+                  ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                  : drawingActive
+                    ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
+                    : 'bg-white text-gray-700 hover:bg-gray-50 hover:shadow-sm'
               }`}
             >
               <Square className="w-4 h-4" />
               <span>Rectangle</span>
             </button>
-            {showRectangleDropdown && !drawingActive && (
+            {showRectangleDropdown && !drawingActive && !disabled && (
               <div className="absolute left-0 mt-2 w-32 bg-white border border-gray-200 rounded shadow-lg z-10">
                 <button
                   className="block w-full text-left px-3 py-1 text-sm text-gray-700 hover:bg-gray-100"
@@ -85,16 +91,19 @@ const Toolbox = ({
           <div className="relative">
             <button
               onClick={handlePolygonClick}
+              disabled={disabled}
               className={`flex items-center gap-2 px-4 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
-                polygonActive
-                  ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
-                  : 'bg-white text-gray-700 hover:bg-gray-50 hover:shadow-sm'
+                disabled
+                  ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                  : polygonActive
+                    ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
+                    : 'bg-white text-gray-700 hover:bg-gray-50 hover:shadow-sm'
               }`}
             >
               <Shapes className="w-4 h-4" />
               <span>Polygon</span>
             </button>
-            {showPolygonDropdown && !polygonActive && (
+            {showPolygonDropdown && !polygonActive && !disabled && (
               <div className="absolute left-0 mt-2 w-32 bg-white border border-gray-200 rounded shadow-lg z-10">
                 <button
                   className="block w-full text-left px-3 py-1 text-sm text-gray-700 hover:bg-gray-100"


### PR DESCRIPTION
## Summary
- Disable rectangle and polygon tools and layer panel until image scale is defined
- Display a warning prompting users to scale the image first

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a5b8188a408331b02a71275b070bec