### PR TITLE
feat: prompt for annotations and auto layer activation

### DIFF
--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -7,6 +7,7 @@ import LayerPanel from './LayerPanel';
 import CropModal from './CropModal';
 import CanvasWithGrid from './CanvasWithGrid';
 import ScaleModal from './ScaleModal';
+import AnnotationPrompt from './AnnotationPrompt';
 
 const AnnotationCanvas = () => {
   const canvasRef = useRef(null);
@@ -32,6 +33,7 @@ const AnnotationCanvas = () => {
   const [scaleRatio, setScaleRatio] = useState(null);
   const [scaleModalOpen, setScaleModalOpen] = useState(false);
   const [pendingScaleLength, setPendingScaleLength] = useState(null);
+  const [annotationPromptOpen, setAnnotationPromptOpen] = useState(false);
   const currentPolygonPoints = useRef([]);
   const currentPolygonLines = useRef([]);
   const currentPolygonCircles = useRef([]);
@@ -44,7 +46,7 @@ const AnnotationCanvas = () => {
   const [drawingActive, setDrawingActive] = useState(false);
   const [polygonActive, setPolygonActive] = useState(false);
   const [selectedEntity, setSelectedEntity] = useState('fenetre');
-const [layerVisibility, setLayerVisibility] = useState({
+  const [layerVisibility, setLayerVisibility] = useState({
     fenetre: true,
     porte: true,
     facade: true,
@@ -57,6 +59,18 @@ const [layerVisibility, setLayerVisibility] = useState({
 
   const toggleLayer = (layer) => {
     setLayerVisibility((prev) => ({ ...prev, [layer]: !prev[layer] }));
+  };
+
+  const activateEntityLayer = (entity) => {
+    if (entity === 'fenetre' || entity === 'porte' || entity === 'facade') {
+      setLayerVisibility((prev) => ({
+        ...prev,
+        fenetre: entity === 'fenetre',
+        porte: entity === 'porte',
+        facade: entity === 'facade',
+      }));
+      setAnnotationPromptOpen(false);
+    }
   };
     useEffect(() => {
     layerVisibilityRef.current = layerVisibility;
@@ -376,6 +390,7 @@ const [layerVisibility, setLayerVisibility] = useState({
         rectRef.current.setCoords();
         annotationsHistory.current.push(rectRef.current);
         redoStack.current = [];
+        activateEntityLayer(selectedEntityRef.current);
       }
     });
 
@@ -408,6 +423,7 @@ const [layerVisibility, setLayerVisibility] = useState({
       canvas.add(polygon);
       annotationsHistory.current.push(polygon);
       redoStack.current = [];
+      activateEntityLayer(selectedEntityRef.current);
       currentPolygonLines.current.forEach(line => canvas.remove(line));
       currentPolygonCircles.current.forEach(c => canvas.remove(c));
       if (previewLine.current) {
@@ -769,11 +785,16 @@ ref.current = fabricImg;
           }
           setScaleModalOpen(false);
           setPendingScaleLength(null);
+          setAnnotationPromptOpen(true);
         }}
         onCancel={() => {
           setScaleModalOpen(false);
           setPendingScaleLength(null);
         }}
+      />
+      <AnnotationPrompt
+        isOpen={annotationPromptOpen}
+        onClose={() => setAnnotationPromptOpen(false)}
       />
       <CropModal
         cropMode={cropMode}

--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -53,12 +53,30 @@ const AnnotationCanvas = () => {
     baseImage: false,
     processedImage: true,
   });
+  const [annotationCounts, setAnnotationCounts] = useState({
+    fenetre: 0,
+    porte: 0,
+    facade: 0,
+  });
   const layerVisibilityRef = useRef(layerVisibility);
   const baseImageRef = useRef(null);
   const processedImageRef = useRef(null);
 
   const toggleLayer = (layer) => {
     setLayerVisibility((prev) => ({ ...prev, [layer]: !prev[layer] }));
+  };
+
+  const incrementAnnotationCount = (type) => {
+    if (!['fenetre', 'porte', 'facade'].includes(type)) return;
+    setAnnotationCounts((prev) => ({ ...prev, [type]: prev[type] + 1 }));
+  };
+
+  const decrementAnnotationCount = (type) => {
+    if (!['fenetre', 'porte', 'facade'].includes(type)) return;
+    setAnnotationCounts((prev) => ({
+      ...prev,
+      [type]: Math.max(0, prev[type] - 1),
+    }));
   };
 
   const activateEntityLayer = (entity) => {
@@ -69,6 +87,13 @@ const AnnotationCanvas = () => {
       }));
       setAnnotationPromptOpen(false);
     }
+  };
+
+  const layerToggleDisabled = {
+    fenetre: annotationCounts.fenetre === 0,
+    porte: annotationCounts.porte === 0,
+    facade: annotationCounts.facade === 0,
+    processedImage: false,
   };
     useEffect(() => {
     layerVisibilityRef.current = layerVisibility;
@@ -155,18 +180,19 @@ const AnnotationCanvas = () => {
       redoStack.current.push(annotation);
       canvas.remove(annotation);
       canvas.renderAll();
-      
+      decrementAnnotationCount(annotation.dataType);
     }
   };
 
   const redo = () => {
     const canvas = fabricRef.current;
     if (!canvas) return;
-      const annotation = redoStack.current.pop();
+    const annotation = redoStack.current.pop();
     if (annotation) {
       canvas.add(annotation);
       annotationsHistory.current.push(annotation);
       canvas.renderAll();
+      incrementAnnotationCount(annotation.dataType);
     }
   };
 
@@ -175,12 +201,23 @@ const AnnotationCanvas = () => {
     if (!canvas) return;
     const activeObjects = canvas.getActiveObjects();
     if (!activeObjects.length) return;
+    const removedCounts = {};
     activeObjects.forEach((obj) => {
       canvas.remove(obj);
       const index = annotationsHistory.current.indexOf(obj);
       if (index !== -1) {
         annotationsHistory.current.splice(index, 1);
       }
+      if (obj.dataType) {
+        removedCounts[obj.dataType] = (removedCounts[obj.dataType] || 0) + 1;
+      }
+    });
+    setAnnotationCounts((prev) => {
+      const updated = { ...prev };
+      Object.keys(removedCounts).forEach((type) => {
+        updated[type] = Math.max(0, updated[type] - removedCounts[type]);
+      });
+      return updated;
     });
     canvas.discardActiveObject();
     canvas.requestRenderAll();
@@ -389,6 +426,7 @@ const AnnotationCanvas = () => {
         annotationsHistory.current.push(rectRef.current);
         redoStack.current = [];
         activateEntityLayer(selectedEntityRef.current);
+        incrementAnnotationCount(selectedEntityRef.current);
       }
     });
 
@@ -422,6 +460,7 @@ const AnnotationCanvas = () => {
       annotationsHistory.current.push(polygon);
       redoStack.current = [];
       activateEntityLayer(selectedEntityRef.current);
+      incrementAnnotationCount(selectedEntityRef.current);
       currentPolygonLines.current.forEach(line => canvas.remove(line));
       currentPolygonCircles.current.forEach(c => canvas.remove(c));
       if (previewLine.current) {
@@ -515,6 +554,7 @@ const toggleScaleMode = () => {
     canvas.renderAll();
     annotationsHistory.current = [];
     redoStack.current = [];
+    setAnnotationCounts({ fenetre: 0, porte: 0, facade: 0 });
   };
 
   const exportAnnotations = () => {
@@ -773,6 +813,7 @@ ref.current = fabricImg;
           layerVisibility={layerVisibility}
           toggleLayer={toggleLayer}
           disabled={!toolsEnabled}
+          layerToggleDisabled={layerToggleDisabled}
         />
       </div>
       <ScaleModal

--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -62,12 +62,10 @@ const AnnotationCanvas = () => {
   };
 
   const activateEntityLayer = (entity) => {
-    if (entity === 'fenetre' || entity === 'porte' || entity === 'facade') {
+    if (['fenetre', 'porte', 'facade'].includes(entity)) {
       setLayerVisibility((prev) => ({
         ...prev,
-        fenetre: entity === 'fenetre',
-        porte: entity === 'porte',
-        facade: entity === 'facade',
+        [entity]: true,
       }));
       setAnnotationPromptOpen(false);
     }

--- a/src/components/AnnotationPrompt.js
+++ b/src/components/AnnotationPrompt.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const AnnotationPrompt = ({ isOpen, onClose }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="absolute top-4 left-1/2 transform -translate-x-1/2 bg-blue-100 text-blue-800 px-4 py-2 rounded shadow z-50 flex items-center space-x-4">
+      <span>Veuillez annoter les portes et les fenêtres.</span>
+      <button
+        onClick={onClose}
+        className="px-2 py-1 bg-blue-500 text-white rounded"
+      >
+        OK
+      </button>
+    </div>
+  );
+};
+
+export default AnnotationPrompt;

--- a/src/components/LayerPanel.js
+++ b/src/components/LayerPanel.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const LayerPanel = ({ layerVisibility, toggleLayer, disabled }) => (
+const LayerPanel = ({ layerVisibility, toggleLayer, disabled, layerToggleDisabled = {} }) => (
   <aside
     className={`w-64 bg-gradient-to-b from-white via-gray-50 to-white border-l border-gray-200 shadow-sm p-4 ${
       disabled ? 'opacity-50 pointer-events-none' : ''
@@ -13,21 +13,26 @@ const LayerPanel = ({ layerVisibility, toggleLayer, disabled }) => (
         { key: 'porte', label: 'Porte' },
         { key: 'facade', label: 'Façade' },
         { key: 'processedImage', label: 'Image traitée' },
-      ].map(({ key, label }) => (
-        <label
-          key={key}
-          className="flex items-center space-x-2 px-2 py-1 rounded hover:bg-gray-100"
-        >
-          <input
-            type="checkbox"
-            className="form-checkbox h-4 w-4 text-blue-600 rounded focus:ring-blue-500"
-            checked={layerVisibility[key]}
-            onChange={() => toggleLayer(key)}
-            disabled={disabled}
-          />
-          <span>{label}</span>
-        </label>
-      ))}
+      ].map(({ key, label }) => {
+        const isDisabled = disabled || layerToggleDisabled[key];
+        return (
+          <label
+            key={key}
+            className={`flex items-center space-x-2 px-2 py-1 rounded hover:bg-gray-100 ${
+              isDisabled ? 'opacity-50 pointer-events-none' : ''
+            }`}
+          >
+            <input
+              type="checkbox"
+              className="form-checkbox h-4 w-4 text-blue-600 rounded focus:ring-blue-500"
+              checked={layerVisibility[key]}
+              onChange={() => toggleLayer(key)}
+              disabled={isDisabled}
+            />
+            <span>{label}</span>
+          </label>
+        );
+      })}
     </div>
   </aside>
 );


### PR DESCRIPTION
## Summary
- prompt users to annotate doors and windows after scaling an image
- automatically enable corresponding layer when a door or window annotation is added

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5c76dd5e8833195c2fb29d7233a37