### PR TITLE
Align annotation prompt with scale instruction

### DIFF
--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -783,6 +783,10 @@ ref.current = fabricImg;
               Veuillez mettre à l'échelle l'image d'abord
             </div>
           )}
+          <AnnotationPrompt
+            isOpen={annotationPromptOpen}
+            onClose={() => setAnnotationPromptOpen(false)}
+          />
         </div>
         <LayerPanel
           layerVisibility={layerVisibility}
@@ -805,10 +809,6 @@ ref.current = fabricImg;
           setScaleModalOpen(false);
           setPendingScaleLength(null);
         }}
-      />
-      <AnnotationPrompt
-        isOpen={annotationPromptOpen}
-        onClose={() => setAnnotationPromptOpen(false)}
       />
       <CropModal
         cropMode={cropMode}

--- a/src/components/AnnotationPrompt.js
+++ b/src/components/AnnotationPrompt.js
@@ -4,11 +4,11 @@ const AnnotationPrompt = ({ isOpen, onClose }) => {
   if (!isOpen) return null;
 
   return (
-    <div className="absolute top-4 left-1/2 transform -translate-x-1/2 bg-blue-100 text-blue-800 px-4 py-2 rounded shadow z-50 flex items-center space-x-4">
-
-      <div className="absolute top-4 left-1/2 transform -translate-x-1/2 bg-yellow-200 text-red-600 px-6 py-3 rounded shadow text-lg font-semibold whitespace-nowrap">
-        Veuillez annoter les portes et les fenêtres.
-      </div>
+    <div
+      className="absolute top-4 left-1/2 transform -translate-x-1/2 bg-yellow-100 text-yellow-800 px-4 py-2 rounded shadow z-50"
+      onClick={onClose}
+    >
+      Veuillez annoter les portes et les fenêtres.
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Ensure annotation prompt appears at top center with same styling as scale instruction
- Render annotation prompt within canvas container and close on click

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a83fc57dd08331bfcde90bde05cf7c