### PR TITLE
feat: resize crop image to fit viewport

### DIFF
--- a/src/components/CropModal.js
+++ b/src/components/CropModal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactCrop from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
 
@@ -14,6 +14,18 @@ const CropModal = ({
   addImageDirectly,
   onCancel
 }) => {
+  const [imgMaxHeight, setImgMaxHeight] = useState('60vh');
+
+  useEffect(() => {
+    const updateMaxHeight = () => {
+      const offset = 240; // reserve space for header and buttons
+      setImgMaxHeight(`${window.innerHeight - offset}px`);
+    };
+    updateMaxHeight();
+    window.addEventListener('resize', updateMaxHeight);
+    return () => window.removeEventListener('resize', updateMaxHeight);
+  }, []);
+
   if (cropMode !== 'cropImage' || !selectedImage) return null;
 
   return (
@@ -46,7 +58,8 @@ const CropModal = ({
             <img
               ref={imgRef}
               src={selectedImage}
-              className="max-w-full max-h-[60vh] rounded-lg shadow-lg mx-auto"
+              className="max-w-full rounded-lg shadow-lg mx-auto"
+              style={{ maxHeight: imgMaxHeight }}
               onLoad={() => {
                 if (imgRef.current) {
                   const { width, height } = imgRef.current;


### PR DESCRIPTION
## Summary
- resize crop modal image dynamically based on window height to prevent scrolling

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a85dec050c83319c1f7eae984a9671