### PR TITLE
Fix polygon export scaling and improve GeoJSON download

### DIFF
--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -563,7 +563,12 @@ const toggleScaleMode = () => {
           };
         }
       } else if (obj.type === 'polygon') {
-        const pixelPoints = obj.points.map(p => ({ x: p.x + obj.left, y: p.y + obj.top }));
+        const scaleX = obj.scaleX ?? 1;
+        const scaleY = obj.scaleY ?? 1;
+        const pixelPoints = obj.points.map(p => ({
+          x: obj.left + p.x * scaleX,
+          y: obj.top + p.y * scaleY,
+        }));
         polygon = pixelPoints.map(p => pixelToGeo(p.x, p.y, imgWidth, imgHeight));
         polygon.push(polygon[0]);
         if (scaleRatio) {
@@ -608,7 +613,9 @@ const toggleScaleMode = () => {
     const a = document.createElement('a');
     a.href = url;
     a.download = "annotations.geojson";
+    document.body.appendChild(a);
     a.click();
+    document.body.removeChild(a);
     URL.revokeObjectURL(url);
   };
 


### PR DESCRIPTION
## Summary
- correct polygon coordinate export by respecting object scaling
- ensure GeoJSON export triggers a browser download reliably

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a88114c08c8331b4aab6078726e0a2