### PR TITLE
Refine toolbox dropdown interaction

### DIFF
--- a/src/components/Toolbox.js
+++ b/src/components/Toolbox.js
@@ -17,6 +17,8 @@ const Toolbox = ({
 
   const handlePolygonClick = () => {
     if (disabled) return;
+    // Close the rectangle dropdown if it's open
+    setShowRectangleDropdown(false);
     if (polygonActive) {
       togglePolygonDrawing();
     } else {
@@ -26,6 +28,8 @@ const Toolbox = ({
 
   const handleRectangleClick = () => {
     if (disabled) return;
+    // Close the polygon dropdown if it's open
+    setShowPolygonDropdown(false);
     if (drawingActive) {
       toggleDrawing();
     } else {
@@ -66,7 +70,7 @@ const Toolbox = ({
               <span>Rectangle</span>
             </button>
             {showRectangleDropdown && !drawingActive && !disabled && (
-              <div className="absolute left-0 mt-2 w-32 bg-white border border-gray-200 rounded shadow-lg z-10">
+              <div className="absolute top-0 left-full ml-2 w-32 bg-white border border-gray-200 rounded shadow-lg z-10">
                 <button
                   className="block w-full text-left px-3 py-1 text-sm text-gray-700 hover:bg-gray-100"
                   onClick={() => startRectangleWithType('fenetre')}
@@ -104,7 +108,7 @@ const Toolbox = ({
               <span>Polygon</span>
             </button>
             {showPolygonDropdown && !polygonActive && !disabled && (
-              <div className="absolute left-0 mt-2 w-32 bg-white border border-gray-200 rounded shadow-lg z-10">
+              <div className="absolute top-0 left-full ml-2 w-32 bg-white border border-gray-200 rounded shadow-lg z-10">
                 <button
                   className="block w-full text-left px-3 py-1 text-sm text-gray-700 hover:bg-gray-100"
                   onClick={() => startPolygonWithType('fenetre')}

--- a/src/components/Toolbox.js
+++ b/src/components/Toolbox.js
@@ -21,6 +21,7 @@ const Toolbox = ({
     setShowRectangleDropdown(false);
     if (polygonActive) {
       togglePolygonDrawing();
+      setShowPolygonDropdown(true);
     } else {
       setShowPolygonDropdown((prev) => !prev);
     }
@@ -32,6 +33,7 @@ const Toolbox = ({
     setShowPolygonDropdown(false);
     if (drawingActive) {
       toggleDrawing();
+      setShowRectangleDropdown(true);
     } else {
       setShowRectangleDropdown((prev) => !prev);
     }


### PR DESCRIPTION
## Summary
- Close the other dropdown when selecting rectangle or polygon tools
- Display toolbox dropdown menus to the side instead of over other buttons

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8aa93a5548331939eba6e1c393188