### PR TITLE
Add duplication tool to toolbox

### DIFF
--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -200,6 +200,29 @@ const AnnotationCanvas = () => {
     canvas.discardActiveObject();
     canvas.requestRenderAll();
   };
+
+  const duplicateSelected = (count) => {
+    const canvas = fabricRef.current;
+    if (!canvas) return;
+    const activeObjects = canvas.getActiveObjects();
+    if (!activeObjects.length) return;
+    activeObjects.forEach((obj) => {
+      for (let i = 0; i < count; i++) {
+        const offset = 10 * (i + 1);
+        obj.clone((cloned) => {
+          cloned.set({
+            left: obj.left + offset,
+            top: obj.top + offset,
+          });
+          canvas.add(cloned);
+          annotationsHistory.current.push(cloned);
+          canvas.renderAll();
+        });
+      }
+    });
+    canvas.discardActiveObject();
+    redoStack.current = [];
+  };
  // Allow keyboard shortcuts (Ctrl/Cmd + Z or Y) to trigger undo/redo
   useEffect(() => {
     const handleKeyDown = (e) => {
@@ -868,6 +891,7 @@ ref.current = fabricImg;
           selectedEntity={selectedEntity}
           setSelectedEntity={setSelectedEntity}
           disabled={!toolsEnabled}
+          duplicateSelected={duplicateSelected}
         />
         <div className="flex-1 p-2 md:p-6 flex items-center justify-center relative">
           <CanvasWithGrid ref={canvasRef} />

--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -206,18 +206,22 @@ const AnnotationCanvas = () => {
     if (!canvas) return;
     const activeObjects = canvas.getActiveObjects();
     if (!activeObjects.length) return;
+    const propertiesToInclude = ['dataType'];
     activeObjects.forEach((obj) => {
       for (let i = 0; i < count; i++) {
         const offset = 10 * (i + 1);
-        obj.clone((cloned) => {
-          cloned.set({
-            left: obj.left + offset,
-            top: obj.top + offset,
-          });
-          canvas.add(cloned);
-          annotationsHistory.current.push(cloned);
-          canvas.renderAll();
-        });
+        obj.clone(
+          (cloned) => {
+            cloned.set({
+              left: obj.left + offset,
+              top: obj.top + offset,
+            });
+            canvas.add(cloned);
+            annotationsHistory.current.push(cloned);
+            canvas.renderAll();
+          },
+          propertiesToInclude
+        );
       }
     });
     canvas.discardActiveObject();

--- a/src/components/Toolbox.js
+++ b/src/components/Toolbox.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Ruler, Square, Shapes, Circle } from 'lucide-react';
+import { Ruler, Square, Shapes, Circle, CopyPlus } from 'lucide-react';
 
 const Toolbox = ({
   drawingActive,
@@ -13,9 +13,11 @@ const Toolbox = ({
   selectedEntity,
   setSelectedEntity,
   disabled,
+  duplicateSelected,
 }) => {
   const [showPolygonDropdown, setShowPolygonDropdown] = useState(false);
   const [showRectangleDropdown, setShowRectangleDropdown] = useState(false);
+  const [duplicationCount, setDuplicationCount] = useState(1);
 
   const handlePolygonClick = () => {
     if (disabled) return;
@@ -48,6 +50,12 @@ const Toolbox = ({
     if (!drawingActive) {
       toggleDrawing();
     }
+  };
+
+  const handleDuplicate = () => {
+    if (disabled) return;
+    const count = Math.max(1, parseInt(duplicationCount, 10) || 1);
+    duplicateSelected(count);
   };
 
   return (
@@ -156,6 +164,28 @@ const Toolbox = ({
             <Ruler className="w-4 h-4" />
             <span>Échelle</span>
           </button>
+          <div className="flex items-center gap-2 pt-2">
+            <input
+              type="number"
+              min="1"
+              value={duplicationCount}
+              onChange={(e) => setDuplicationCount(e.target.value)}
+              className="w-16 px-2 py-1 border rounded-md text-sm"
+              disabled={disabled}
+            />
+            <button
+              onClick={handleDuplicate}
+              disabled={disabled}
+              className={`flex items-center gap-2 px-4 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
+                disabled
+                  ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                  : 'bg-white text-gray-700 hover:bg-gray-50 hover:shadow-sm'
+              }`}
+            >
+              <CopyPlus className="w-4 h-4" />
+              <span>Dupliquer</span>
+            </button>
+          </div>
         </div>
       </div>
     </aside>


### PR DESCRIPTION
## Summary
- add CopyPlus-powered duplicate button with count input in toolbox
- support duplicating selected objects n times in canvas

## Testing
- `npx jest src/App.test.js --runInBand --detectOpenHandles` *(fails: Support for the experimental syntax 'jsx' isn't enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68ad764377e08331a960c69518cd0ebf