### PR TITLE
feat: add measurement tool

### DIFF
--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -269,9 +269,11 @@ const AnnotationCanvas = () => {
             measureLineRef.current.set({ x2: pointer.x, y2: pointer.y });
           }
           const lengthPx = Math.hypot(pointer.x - startX.current, pointer.y - startY.current);
-          let label = `${lengthPx.toFixed(2)} px`;
+          let label = '';
           if (scaleRatio) {
-            label += ` (${(lengthPx * scaleRatio).toFixed(2)} cm)`;
+            label = `${(lengthPx * scaleRatio).toFixed(2)} cm`;
+          } else {
+            label = 'Échelle non définie';
           }
           if (measureTextRef.current) {
             canvas.remove(measureTextRef.current);
@@ -296,9 +298,11 @@ const AnnotationCanvas = () => {
           if (target.type === 'rect') {
             const width = target.width * target.scaleX;
             const height = target.height * target.scaleY;
-            msg = scaleRatio
-              ? `L: ${(width * scaleRatio).toFixed(2)} cm  H: ${(height * scaleRatio).toFixed(2)} cm  S: ${(width * height * scaleRatio * scaleRatio).toFixed(2)} cm²`
-              : `L: ${width.toFixed(2)} px  H: ${height.toFixed(2)} px  S: ${(width * height).toFixed(2)} px²`;
+            if (scaleRatio) {
+              msg = `L: ${(width * scaleRatio).toFixed(2)} cm  H: ${(height * scaleRatio).toFixed(2)} cm  S: ${(width * height * scaleRatio * scaleRatio).toFixed(2)} cm²`;
+            } else {
+              msg = 'Échelle non définie';
+            }
           } else if (target.type === 'polygon') {
             const pts = target.points.map(p => ({
               x: target.left + (p.x - target.pathOffset.x) * target.scaleX,
@@ -306,9 +310,11 @@ const AnnotationCanvas = () => {
             }));
             const areaPx = polygonArea(pts);
             const perPx = polygonPerimeter(pts);
-            msg = scaleRatio
-              ? `P: ${(perPx * scaleRatio).toFixed(2)} cm  S: ${(areaPx * scaleRatio * scaleRatio).toFixed(2)} cm²`
-              : `P: ${perPx.toFixed(2)} px  S: ${areaPx.toFixed(2)} px²`;
+            if (scaleRatio) {
+              msg = `P: ${(perPx * scaleRatio).toFixed(2)} cm  S: ${(areaPx * scaleRatio * scaleRatio).toFixed(2)} cm²`;
+            } else {
+              msg = 'Échelle non définie';
+            }
           }
           if (msg) {
             if (measureTextRef.current) {
@@ -463,9 +469,11 @@ const AnnotationCanvas = () => {
       if (isMeasureMode.current && measuring.current && measureLineRef.current) {
         measureLineRef.current.set({ x2: pointer.x, y2: pointer.y });
         const lengthPx = Math.hypot(pointer.x - startX.current, pointer.y - startY.current);
-        let label = `${lengthPx.toFixed(2)} px`;
+        let label = '';
         if (scaleRatio) {
-          label += ` (${(lengthPx * scaleRatio).toFixed(2)} cm)`;
+          label = `${(lengthPx * scaleRatio).toFixed(2)} cm`;
+        } else {
+          label = 'Échelle non définie';
         }
         if (measureTextRef.current) {
           measureTextRef.current.set({ left: pointer.x + 10, top: pointer.y + 10, text: label });

--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Canvas, Circle, Line, Rect, Polygon, Path, Image as FabricImage, util } from 'fabric';
+import { Canvas, Circle, Line, Rect, Polygon, Path, Image as FabricImage, util, Text } from 'fabric';
 import TopBar from './TopBar';
 import Toolbox from './Toolbox';
 import LayerPanel from './LayerPanel';
@@ -31,6 +31,11 @@ const AnnotationCanvas = () => {
   const isScaleMode = useRef(false);
   const scaleLineRef = useRef(null);
   const [scaleActive, setScaleActive] = useState(false);
+  const isMeasureMode = useRef(false);
+  const measureLineRef = useRef(null);
+  const measureTextRef = useRef(null);
+  const measuring = useRef(false);
+  const [measureActive, setMeasureActive] = useState(false);
   const [scaleRatio, setScaleRatio] = useState(null);
   const [scaleModalOpen, setScaleModalOpen] = useState(false);
   const [pendingScaleLength, setPendingScaleLength] = useState(null);
@@ -257,6 +262,95 @@ const AnnotationCanvas = () => {
     
     canvas.on('mouse:down', function (opt) {
       const pointer = canvas.getPointer(opt.e);
+      if (isMeasureMode.current) {
+        if (measuring.current) {
+          measuring.current = false;
+          if (measureLineRef.current) {
+            measureLineRef.current.set({ x2: pointer.x, y2: pointer.y });
+          }
+          const lengthPx = Math.hypot(pointer.x - startX.current, pointer.y - startY.current);
+          let label = `${lengthPx.toFixed(2)} px`;
+          if (scaleRatio) {
+            label += ` (${(lengthPx * scaleRatio).toFixed(2)} cm)`;
+          }
+          if (measureTextRef.current) {
+            canvas.remove(measureTextRef.current);
+            measureTextRef.current = null;
+          }
+          const text = new Text(label, {
+            left: pointer.x + 10,
+            top: pointer.y + 10,
+            fontSize: 14,
+            fill: '#0000FF',
+            selectable: false,
+            evented: false,
+          });
+          measureTextRef.current = text;
+          canvas.add(text);
+          canvas.renderAll();
+          return;
+        }
+        const target = opt.target;
+        if (target && target !== canvas.backgroundImage) {
+          let msg = '';
+          if (target.type === 'rect') {
+            const width = target.width * target.scaleX;
+            const height = target.height * target.scaleY;
+            msg = scaleRatio
+              ? `L: ${(width * scaleRatio).toFixed(2)} cm  H: ${(height * scaleRatio).toFixed(2)} cm  S: ${(width * height * scaleRatio * scaleRatio).toFixed(2)} cm²`
+              : `L: ${width.toFixed(2)} px  H: ${height.toFixed(2)} px  S: ${(width * height).toFixed(2)} px²`;
+          } else if (target.type === 'polygon') {
+            const pts = target.points.map(p => ({
+              x: target.left + (p.x - target.pathOffset.x) * target.scaleX,
+              y: target.top + (p.y - target.pathOffset.y) * target.scaleY,
+            }));
+            const areaPx = polygonArea(pts);
+            const perPx = polygonPerimeter(pts);
+            msg = scaleRatio
+              ? `P: ${(perPx * scaleRatio).toFixed(2)} cm  S: ${(areaPx * scaleRatio * scaleRatio).toFixed(2)} cm²`
+              : `P: ${perPx.toFixed(2)} px  S: ${areaPx.toFixed(2)} px²`;
+          }
+          if (msg) {
+            if (measureTextRef.current) {
+              canvas.remove(measureTextRef.current);
+              measureTextRef.current = null;
+            }
+            const text = new Text(msg, {
+              left: pointer.x + 10,
+              top: pointer.y + 10,
+              fontSize: 14,
+              fill: '#0000FF',
+              selectable: false,
+              evented: false,
+            });
+            measureTextRef.current = text;
+            canvas.add(text);
+            canvas.renderAll();
+            return;
+          }
+        }
+        startX.current = pointer.x;
+        startY.current = pointer.y;
+        measuring.current = true;
+        if (measureLineRef.current) {
+          canvas.remove(measureLineRef.current);
+          measureLineRef.current = null;
+        }
+        if (measureTextRef.current) {
+          canvas.remove(measureTextRef.current);
+          measureTextRef.current = null;
+        }
+        const line = new Line([pointer.x, pointer.y, pointer.x, pointer.y], {
+          stroke: '#0000FF',
+          strokeWidth: 2,
+          selectable: false,
+          evented: false,
+        });
+        measureLineRef.current = line;
+        canvas.add(line);
+        canvas.renderAll();
+        return;
+      }
       if (isScaleMode.current) {
         startX.current = pointer.x;
         startY.current = pointer.y;
@@ -366,6 +460,30 @@ const AnnotationCanvas = () => {
 
     canvas.on('mouse:move', function (opt) {
       const pointer = canvas.getPointer(opt.e);
+      if (isMeasureMode.current && measuring.current && measureLineRef.current) {
+        measureLineRef.current.set({ x2: pointer.x, y2: pointer.y });
+        const lengthPx = Math.hypot(pointer.x - startX.current, pointer.y - startY.current);
+        let label = `${lengthPx.toFixed(2)} px`;
+        if (scaleRatio) {
+          label += ` (${(lengthPx * scaleRatio).toFixed(2)} cm)`;
+        }
+        if (measureTextRef.current) {
+          measureTextRef.current.set({ left: pointer.x + 10, top: pointer.y + 10, text: label });
+        } else {
+          const text = new Text(label, {
+            left: pointer.x + 10,
+            top: pointer.y + 10,
+            fontSize: 14,
+            fill: '#0000FF',
+            selectable: false,
+            evented: false,
+          });
+          measureTextRef.current = text;
+          canvas.add(text);
+        }
+        canvas.renderAll();
+        return;
+      }
       if (isScaleMode.current && drawing.current && scaleLineRef.current) {
         scaleLineRef.current.set({ x2: pointer.x, y2: pointer.y });
         canvas.renderAll();
@@ -524,6 +642,9 @@ const AnnotationCanvas = () => {
       isArcMode.current = false;
       setArcActive(false);
     }
+    if (isDrawingMode.current && isMeasureMode.current) {
+      toggleMeasureMode();
+    }
   };
 
   const togglePolygonDrawing = () => {
@@ -554,6 +675,9 @@ const AnnotationCanvas = () => {
       isArcMode.current = false;
       setArcActive(false);
     }
+    if (isPolygonMode.current && isMeasureMode.current) {
+      toggleMeasureMode();
+    }
   };
   const toggleArcDrawing = () => {
     const canvas = fabricRef.current;
@@ -579,8 +703,11 @@ const AnnotationCanvas = () => {
 
       canvas.renderAll();
     }
+    if (isArcMode.current && isMeasureMode.current) {
+      toggleMeasureMode();
+    }
   };
-const toggleScaleMode = () => {
+  const toggleScaleMode = () => {
     const canvas = fabricRef.current;
     isScaleMode.current = !isScaleMode.current;
     setScaleActive(isScaleMode.current);
@@ -602,6 +729,47 @@ const toggleScaleMode = () => {
         previewLine.current = null;
       }
 
+      canvas.renderAll();
+    }
+    if (isScaleMode.current && isMeasureMode.current) {
+      toggleMeasureMode();
+    }
+  };
+  const toggleMeasureMode = () => {
+    const canvas = fabricRef.current;
+    isMeasureMode.current = !isMeasureMode.current;
+    setMeasureActive(isMeasureMode.current);
+
+    if (isMeasureMode.current) {
+      isDrawingMode.current = false;
+      isPolygonMode.current = false;
+      isArcMode.current = false;
+      isScaleMode.current = false;
+      setDrawingActive(false);
+      setPolygonActive(false);
+      setArcActive(false);
+      setScaleActive(false);
+
+      currentPolygonPoints.current = [];
+      currentPolygonLines.current.forEach(line => canvas.remove(line));
+      currentPolygonLines.current = [];
+
+      if (previewLine.current) {
+        canvas.remove(previewLine.current);
+        previewLine.current = null;
+      }
+
+      canvas.renderAll();
+    } else {
+      measuring.current = false;
+      if (measureLineRef.current) {
+        canvas.remove(measureLineRef.current);
+        measureLineRef.current = null;
+      }
+      if (measureTextRef.current) {
+        canvas.remove(measureTextRef.current);
+        measureTextRef.current = null;
+      }
       canvas.renderAll();
     }
   };
@@ -861,10 +1029,12 @@ ref.current = fabricImg;
           polygonActive={polygonActive}
           arcActive={arcActive}
           scaleActive={scaleActive}
+          measureActive={measureActive}
           toggleDrawing={toggleDrawing}
           togglePolygonDrawing={togglePolygonDrawing}
           toggleArcDrawing={toggleArcDrawing}
           toggleScaleMode={toggleScaleMode}
+          toggleMeasureMode={toggleMeasureMode}
           selectedEntity={selectedEntity}
           setSelectedEntity={setSelectedEntity}
           disabled={!toolsEnabled}

--- a/src/components/AnnotationCanvas.js
+++ b/src/components/AnnotationCanvas.js
@@ -37,6 +37,7 @@ const AnnotationCanvas = () => {
   const measuring = useRef(false);
   const [measureActive, setMeasureActive] = useState(false);
   const [scaleRatio, setScaleRatio] = useState(null);
+  const scaleRatioRef = useRef(null);
   const [scaleModalOpen, setScaleModalOpen] = useState(false);
   const [pendingScaleLength, setPendingScaleLength] = useState(null);
   const [annotationPromptOpen, setAnnotationPromptOpen] = useState(false);
@@ -69,6 +70,10 @@ const AnnotationCanvas = () => {
   const layerVisibilityRef = useRef(layerVisibility);
   const baseImageRef = useRef(null);
   const processedImageRef = useRef(null);
+
+  useEffect(() => {
+    scaleRatioRef.current = scaleRatio;
+  }, [scaleRatio]);
 
   const toggleLayer = (layer) => {
     setLayerVisibility((prev) => ({ ...prev, [layer]: !prev[layer] }));
@@ -270,8 +275,9 @@ const AnnotationCanvas = () => {
           }
           const lengthPx = Math.hypot(pointer.x - startX.current, pointer.y - startY.current);
           let label = '';
-          if (scaleRatio) {
-            label = `${(lengthPx * scaleRatio).toFixed(2)} cm`;
+          const ratio = scaleRatioRef.current;
+          if (ratio) {
+            label = `${(lengthPx * ratio).toFixed(2)} cm`;
           } else {
             label = 'Échelle non définie';
           }
@@ -298,8 +304,9 @@ const AnnotationCanvas = () => {
           if (target.type === 'rect') {
             const width = target.width * target.scaleX;
             const height = target.height * target.scaleY;
-            if (scaleRatio) {
-              msg = `L: ${(width * scaleRatio).toFixed(2)} cm  H: ${(height * scaleRatio).toFixed(2)} cm  S: ${(width * height * scaleRatio * scaleRatio).toFixed(2)} cm²`;
+            const ratio = scaleRatioRef.current;
+            if (ratio) {
+              msg = `L: ${(width * ratio).toFixed(2)} cm  H: ${(height * ratio).toFixed(2)} cm  S: ${(width * height * ratio * ratio).toFixed(2)} cm²`;
             } else {
               msg = 'Échelle non définie';
             }
@@ -310,8 +317,9 @@ const AnnotationCanvas = () => {
             }));
             const areaPx = polygonArea(pts);
             const perPx = polygonPerimeter(pts);
-            if (scaleRatio) {
-              msg = `P: ${(perPx * scaleRatio).toFixed(2)} cm  S: ${(areaPx * scaleRatio * scaleRatio).toFixed(2)} cm²`;
+            const ratio = scaleRatioRef.current;
+            if (ratio) {
+              msg = `P: ${(perPx * ratio).toFixed(2)} cm  S: ${(areaPx * ratio * ratio).toFixed(2)} cm²`;
             } else {
               msg = 'Échelle non définie';
             }
@@ -470,8 +478,9 @@ const AnnotationCanvas = () => {
         measureLineRef.current.set({ x2: pointer.x, y2: pointer.y });
         const lengthPx = Math.hypot(pointer.x - startX.current, pointer.y - startY.current);
         let label = '';
-        if (scaleRatio) {
-          label = `${(lengthPx * scaleRatio).toFixed(2)} cm`;
+        const ratio = scaleRatioRef.current;
+        if (ratio) {
+          label = `${(lengthPx * ratio).toFixed(2)} cm`;
         } else {
           label = 'Échelle non définie';
         }

--- a/src/components/Toolbox.js
+++ b/src/components/Toolbox.js
@@ -6,10 +6,12 @@ const Toolbox = ({
   polygonActive,
   arcActive,
   scaleActive,
+  measureActive,
   toggleDrawing,
   togglePolygonDrawing,
   toggleArcDrawing,
   toggleScaleMode,
+  toggleMeasureMode,
   selectedEntity,
   setSelectedEntity,
   disabled,
@@ -144,6 +146,20 @@ const Toolbox = ({
           >
             <Circle className="w-4 h-4" />
             <span>Arc</span>
+          </button>
+          <button
+            onClick={toggleMeasureMode}
+            disabled={disabled}
+            className={`flex items-center gap-2 px-4 py-2 rounded-full font-medium text-sm transition-all duration-300 ease-out transform ${
+              disabled
+                ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                : measureActive
+                  ? 'bg-blue-500 text-white shadow-lg scale-105 hover:bg-blue-600'
+                  : 'bg-white text-gray-700 hover:bg-gray-50 hover:shadow-sm'
+            }`}
+          >
+            <Ruler className="w-4 h-4" />
+            <span>Mesurer</span>
           </button>
           <button
             onClick={toggleScaleMode}


### PR DESCRIPTION
## Summary
- add Mesurer button to toolbox
- implement measurement mode to calculate distances and areas based on scale

## Testing
- `npx jest --runTestsByPath src/App.test.js --watchAll=false` *(fails: Support for the experimental syntax 'jsx' isn't currently enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68ad920096208331938e0d7b51fcd9a2